### PR TITLE
Correctly using "číslo do adresy" field

### DIFF
--- a/includes/ares.php
+++ b/includes/ares.php
@@ -41,7 +41,8 @@ if ( ! function_exists( 'woolab_icdic_ares') ) {
 
                     $cp_1 = $data->AA->CD->__toString();
                     $cp_2 = $data->AA->CO->__toString();
-                    $cp = ( $cp_2 != "" ? $cp_1."/".$cp_2 : $cp_1 );                                                      
+                    $cp = ( $cp_2 != "" ? $cp_1."/".$cp_2 : $cp_1 );
+                    $cp = (empty($cp)?$data->AA->CA->__toString():$cp);
                     $return['adresa'] = $data->AA->NU->__toString() . ' ' . $cp;
 
                     $return['psc'] = $data->AA->PSC->__toString();


### PR DESCRIPTION
Zdravím, používáme tento plugin na jednom z eshopů a jak jsme zjistili, jeden z klientů nemá v ARES číslo popisné ani orientační, ale pouze "číslo do adresy". Tento PR mění chování tak, aby se toto číslo použilo, pokud není nalezeno ČP.