### PR TITLE
Slovak DIC validation fix

### DIFF
--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -162,7 +162,7 @@ function woolab_icdic_checkout_field_process() {
 
 	}
 
-	// VAT
+	// VAT / DIC
 	if ( isset( $_POST['billing_dic'] ) && $_POST['billing_dic'] ) {
 
 		/**
@@ -196,7 +196,7 @@ function woolab_icdic_checkout_field_process() {
 				} elseif ( $country == "SK" ) {
 
 					if ( ! woolab_icdic_verify_dic_sk( $dic ) ) {		
-						wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
+						wc_add_notice( __( 'Enter a valid Tax ID', 'woolab-ic-dic' ), 'error' );
 					}
 				}
 			}
@@ -208,11 +208,11 @@ function woolab_icdic_checkout_field_process() {
 	else {
 		// if IC is set, DIC must be set as well in Slovakia
 		if( !empty( $_POST['billing_ic'] ) && empty( $_POST['billing_dic'] ) && $country == 'SK' ) {
-			wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
+			wc_add_notice( __( 'Enter a valid Tax ID', 'woolab-ic-dic' ), 'error' );
 		}
 	}
 
-	// DIC DPH
+	// IC DPH / DIC DPH
 	if ( isset( $_POST['billing_dic_dph'] ) && $_POST['billing_dic_dph'] && $country == 'SK' ) {
 
 		/**
@@ -221,28 +221,28 @@ function woolab_icdic_checkout_field_process() {
 		 */
 		$dic_dph = preg_replace('/\s+/', '', $_POST['billing_dic_dph']); 
 
-		// Verify DIC DPH
+		// Verify IC DPH
 		// If Validate in VIES
 		if ( woolab_icdic_vies_check() && class_exists('SoapClient') ) {
 					
 			$validator = new DvK\Vat\Validator();
 			
 			if ( ! $validator->validate( $dic_dph )) {
-				wc_add_notice( __( 'Enter a valid VAT DPH number', 'woolab-ic-dic' ), 'error' );
+				wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
 			}
 
 		} else {
 
 			if ( ! woolab_icdic_verify_dic_dph_sk( $dic_dph ) ) {		
-				wc_add_notice( __( 'Enter a valid VAT DPH number', 'woolab-ic-dic' ), 'error' );
+				wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
 			}
 
 		}
-		// DIC DPH has to match to VAT number without SK
+		// IC DPH has to match to Tax ID number without SK
 		if ( $dic_dph && $dic ) {		
 
 			if ( $dic != substr( $dic_dph, 2) ) {		
-				wc_add_notice( __( 'VAT number or VAT DPH is not valid.', 'woolab-ic-dic' ), 'error' );
+				wc_add_notice( __( 'Tax ID or VAT number is not valid.', 'woolab-ic-dic' ), 'error' );
 			}
 
 		}

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -178,7 +178,8 @@ function woolab_icdic_checkout_field_process() {
 		if ( $countries->inEurope( $country ) ) {
 
 			// If Validate in VIES
-			if ( woolab_icdic_vies_check() && class_exists('SoapClient') ) {
+			// Slovak DIC cannot (and shouldn't) be validated in VIES
+			if ( woolab_icdic_vies_check() && $country != 'SK' ) {
 					
 				$validator = new DvK\Vat\Validator();
 
@@ -202,6 +203,12 @@ function woolab_icdic_checkout_field_process() {
 
 		}
 
+	}
+	// DIC is mandatory in Slovakia, this is not a VAT number
+	else {
+		if( empty( $_POST['billing_dic'] ) && $country == 'SK' ) {
+			wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
+		}
 	}
 
 	// DIC DPH

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -228,13 +228,13 @@ function woolab_icdic_checkout_field_process() {
 			$validator = new DvK\Vat\Validator();
 			
 			if ( ! $validator->validate( $dic_dph )) {
-				wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
+				wc_add_notice( _x( 'Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic' ), 'error' );
 			}
 
 		} else {
 
 			if ( ! woolab_icdic_verify_dic_dph_sk( $dic_dph ) ) {		
-				wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
+				wc_add_notice( _x( 'Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic' ), 'error' );
 			}
 
 		}

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -206,7 +206,8 @@ function woolab_icdic_checkout_field_process() {
 	}
 	// DIC is mandatory in Slovakia, this is not a VAT number
 	else {
-		if( empty( $_POST['billing_dic'] ) && $country == 'SK' ) {
+		// if IC is set, DIC must be set as well in Slovakia
+		if( !empty( $_POST['billing_ic'] ) && empty( $_POST['billing_dic'] ) && $country == 'SK' ) {
 			wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
 		}
 	}

--- a/languages/woolab-ic-dic.pot
+++ b/languages/woolab-ic-dic.pot
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
@@ -25,7 +25,7 @@ msgstr ""
 msgid "Kybernaut IČO DIČ has now settings, go to the %1$s page and check it out!"
 msgstr ""
 
-#: includes/admin-notice.php:9 includes/filters-actions.php:417
+#: includes/admin-notice.php:9 includes/filters-actions.php:425
 msgid "Settings"
 msgstr ""
 
@@ -58,8 +58,8 @@ msgid "Write a Review"
 msgstr ""
 
 #: includes/filters-actions.php:29 includes/filters-actions.php:66
-#: includes/filters-actions.php:127 includes/filters-actions.php:300
-#: includes/filters-actions.php:325
+#: includes/filters-actions.php:127 includes/filters-actions.php:308
+#: includes/filters-actions.php:333
 msgid "Business ID"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgid "Business ID"
 msgstr ""
 
 #: includes/filters-actions.php:37 includes/filters-actions.php:74
-#: includes/filters-actions.php:304 includes/filters-actions.php:330
+#: includes/filters-actions.php:312 includes/filters-actions.php:338
 msgid "Tax ID"
 msgstr ""
 
@@ -79,7 +79,7 @@ msgid "Tax ID"
 msgstr ""
 
 #: includes/filters-actions.php:45 includes/filters-actions.php:85
-#: includes/filters-actions.php:308 includes/filters-actions.php:339
+#: includes/filters-actions.php:316 includes/filters-actions.php:347
 msgid "VAT reg. no."
 msgstr ""
 
@@ -120,32 +120,32 @@ msgstr[1] ""
 msgid "Unexpected error occurred. Try it again."
 msgstr ""
 
-#: includes/filters-actions.php:186 includes/filters-actions.php:193
-#: includes/filters-actions.php:198
+#: includes/filters-actions.php:187 includes/filters-actions.php:194
+#: includes/filters-actions.php:231 includes/filters-actions.php:237
 msgid "Enter a valid VAT number"
 msgstr ""
 
-#: includes/filters-actions.php:223 includes/filters-actions.php:229
-msgid "Enter a valid VAT DPH number"
+#: includes/filters-actions.php:199 includes/filters-actions.php:211
+msgid "Enter a valid Tax ID"
 msgstr ""
 
-#: includes/filters-actions.php:237
-msgid "VAT number or VAT DPH is not valid."
+#: includes/filters-actions.php:245
+msgid "Tax ID or VAT number is not valid."
 msgstr ""
 
-#: includes/filters-actions.php:269 includes/filters-actions.php:272
+#: includes/filters-actions.php:277 includes/filters-actions.php:280
 msgid "Business ID: "
 msgstr ""
 
-#: includes/filters-actions.php:270 includes/filters-actions.php:273
+#: includes/filters-actions.php:278 includes/filters-actions.php:281
 msgid "Tax ID: "
 msgstr ""
 
-#: includes/filters-actions.php:271 includes/filters-actions.php:274
+#: includes/filters-actions.php:279 includes/filters-actions.php:282
 msgid "VAT reg. no.: "
 msgstr ""
 
-#: includes/filters-actions.php:417
+#: includes/filters-actions.php:425
 msgid "View Kybernaut IČO DIČ settings"
 msgstr ""
 

--- a/languages/woolab-ic-dic.pot
+++ b/languages/woolab-ic-dic.pot
@@ -121,12 +121,16 @@ msgid "Unexpected error occurred. Try it again."
 msgstr ""
 
 #: includes/filters-actions.php:187 includes/filters-actions.php:194
-#: includes/filters-actions.php:231 includes/filters-actions.php:237
 msgid "Enter a valid VAT number"
 msgstr ""
 
 #: includes/filters-actions.php:199 includes/filters-actions.php:211
 msgid "Enter a valid Tax ID"
+msgstr ""
+
+#: includes/filters-actions.php:231 includes/filters-actions.php:237
+msgctxt "IC DPH"
+msgid "Enter a valid VAT number"
 msgstr ""
 
 #: includes/filters-actions.php:245


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- (Update " [ ]" to " [x]" to check a box) -->

### Description & Link to The Issue
[Validácia SK DIČ](https://github.com/vyskoczilova/kybernaut-ic-dic/issues/9) (daňové identifikačné číslo) bola pri aktualizácii pluginu na verziu 1.4.0 opäť aktivovaná voči VIESu, čo nie je správne, nakoľko SK DIČ je len 10 miestne číslo bez "SK" prefixu. Tento commit pridáva výnimku pre kontrolu cez VIES (a odstraňuje duplicitnú kontrolu SoapClient). Taktiež podľa [tohto článku](https://m2b.sk/blog/co-je-to-dic-co-je-icdph-a-rozdiel-medzi-nimi) je SK DIČ povinné a teda bola pridaná validácia tohto poľa a overenie cez už existujúcu funkcionalitu pluginu.

#### What kind of change does this PR introduce? 
<!-- (check at least one) -->

* [x] Bugfix
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 
<!-- (check one) -->

* [ ] Yes
* [x] No

<!-- If yes, please describe the impact and migration path for existing websites: -->
