### PR TITLE
Fixed missing DIC field label

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,1 +1,1 @@
-.woocommerce-checkout .required+.optional,.woocommerce-checkout .woocommerce-billing-fields .woolab-ic-dic-toggle,.woocommerce-checkout .woolab-ic-dic-not-optional>.optional,.woocommerce-checkout .woolab-ic-dic-required{display:none}.woocommerce-checkout .woolab-ic-dic-required+.optional{display:inline}
+.woocommerce-checkout .required+.optional,.woocommerce-checkout .woocommerce-billing-fields .woolab-ic-dic-toggle,.woocommerce-checkout .woolab-ic-dic-not-optional>.optional{display:none}.woocommerce-checkout .woolab-ic-dic-required+.optional{display:inline}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,7 +1,6 @@
 .woocommerce-checkout .woocommerce-billing-fields .woolab-ic-dic-toggle,
 .woocommerce-checkout .required + .optional,
-.woocommerce-checkout .woolab-ic-dic-not-optional > .optional,
-.woocommerce-checkout .woolab-ic-dic-required {
+.woocommerce-checkout .woolab-ic-dic-not-optional > .optional{
   display: none;
 }
 .woocommerce-checkout .woolab-ic-dic-required + .optional {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

### Description & Link to The Issue
Po dlhsom case som sa dostal k pluginu a instaloval som priamo z repozitara a nie moj fork.. Narazil som na problem so zobrazovanim DIC label ci uz pri zapnutom alebo vypnutom "Fake required" filtri. Jedna sa len o jednu triedu v `style.css` navyse, ktora si myslim bola pridana omylom.

#### What kind of change does this PR introduce? 
<!-- (check at least one) -->

* [x] Bugfix
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 
<!-- (check one) -->

* [ ] Yes
* [x] No

<!-- If yes, please describe the impact and migration path for existing websites: -->

