### PR TITLE
Architecture refactor: testable validation, shared VIES seam, settings accessors (v1.11.0)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,7 +10,11 @@
 /gulpfile.js
 .DS_Store
 phpunit.cache
+.phpunit.result.cache
+phpunit.xml
 /tests
+/docs
+/.vscode
 DOCKER_ENV
 docker_tag
 output.log

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -31,9 +31,10 @@ jobs:
           name: woolab-ic-dic
           path: |
             ${{ github.workspace }}
-            !git/**/*
-            !github/**/*
+            !.git/**/*
+            !.github/**/*
             !tests/**/*
+            !docs/**/*
             !DOCKER_ENV
             !docker_tag
             !output.log

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Download here: https://wordpress.org/plugins/woolab-ic-dic/
 
 ## Unreleased changes
 
-* none
+* Refactor (1.11.0): internal architecture cleanup, behaviour-preserving — no change to checkout behaviour, validation messages, or public filters. The checkout field validation was extracted into a pure, unit-tested orchestrator behind a thin hook adapter; the two duplicated VAT-exemption code paths were collapsed onto a single shared VIES verification seam; and all settings reads were consolidated behind named accessors. Adds substantial unit-test coverage.
 
 ## Filters
 

--- a/docs/adr/0001-extract-checkout-validation-orchestrator.md
+++ b/docs/adr/0001-extract-checkout-validation-orchestrator.md
@@ -1,0 +1,93 @@
+# ADR 0001 — Extract the checkout validation orchestrator behind a pure seam
+
+- **Status:** Accepted — implemented 2026-06-26
+- **Deciders:** Karolína Vyskočilová
+- **Related:** `docs/plans/candidate-1-validation-orchestrator.md` (design), architecture
+  review `kybernaut-ic-dic-20260626` candidate 1
+
+## Context
+
+`woolab_icdic_checkout_field_process()` was the plugin's central business logic: all
+CZ/SK/EU company-identifier validation (Business ID, Tax ID, VAT/VIES, ARES) fused into a
+single ~220-line `woocommerce_checkout_process` hook callback. It read `$_POST`, settings,
+`apply_filters`, `get_option`, and `WC()->session` directly, performed network I/O (ARES +
+VIES) inline, and emitted `wc_add_notice()` strings — all interleaved.
+
+Consequences of that shape:
+
+- **Zero test coverage.** The branching could not be exercised without a full WordPress +
+  WooCommerce + network stack, so it had no unit tests despite being the highest-risk code in
+  the plugin.
+- **Hard to reason about / change.** Country rules, VIES quirks, and ARES cross-checks were
+  entangled with i18n, session, and transport concerns.
+
+## Decision
+
+Split the hook into two pieces with a single seam:
+
+1. **A pure decision module** — `includes/validation.php`,
+   `woolab_icdic_validate_checkout( array $input ): array`. No WordPress, no WooCommerce, no
+   network, no i18n. It returns **structured error codes**
+   (`['errors' => [['code', 'data']], 'check_fail_ignored' => bool]`), never translated
+   strings. It calls the existing pure math helpers in `helpers.php` directly; only the
+   genuinely impure collaborators cross the seam.
+
+2. **A thin adapter** — the rewritten hook in `includes/filters-actions.php`. It cleans
+   `$_POST` into values, resolves every setting/filter/option into plain booleans up front
+   ("Option A"), builds the two network closures, calls the pure function, maps each returned
+   code back to its **exact** original notice via `woolab_icdic_checkout_error_message()`, and
+   writes the session flag.
+
+Key design choices (see the plan for the full rationale):
+
+- **Network crosses the seam as plain closures**, not DI/interfaces — proportionate to a
+  procedural PHP 7.3 plugin. `verify_vat` returns a four-state string
+  (`valid|bad_format|invalid|unverifiable`), keeping ibericode (`Validator`, `ViesException`)
+  100% behind the seam; `lookup_ares` is the bare `woolab_icdic_ares` callable.
+- **Structured codes, not strings.** Tests assert on codes; the adapter owns the
+  code→string/text-domain/context mapping. Codes are split by *originating branch* even when
+  the English text is identical (`invalid_vat` / `invalid_dic_cz` / `invalid_vat_dph`) so tests
+  can tell paths apart and traceability to the original is preserved.
+- **Behavior-preserving.** The branching was ported verbatim in logic and emission order.
+  Pre-existing quirks were deliberately kept, not "fixed": the early `return` (which skips
+  writing the session flag) when `billing_country` is unset; the malformed-EU-VAT case that
+  emits **both** `vat_format` and `invalid_vat`; and the `isset($_POST['billing_dic'])` guard
+  on the ARES Tax-ID mismatch (carried as the explicit `dic_present` flag).
+
+## Consequences
+
+**Positive**
+
+- The decision logic is now unit-testable with zero infrastructure. `tests/unit/ValidationTest.php`
+  covers every branch with fake closures (28 tests); full suite is **93 tests / 105 assertions, green**.
+- The adapter is small and obvious; the pure module is navigable and side-effect-free.
+- The four-state `verify_vat` seam and the SK `dic_dph`-else-`dic` selection are reusable by the
+  next refactors (notably the VAT-exempt logic).
+
+**Negative / trade-offs**
+
+- The adapter resolves all flags/closures eagerly even when the relevant field is absent (the
+  original resolved some lazily). On a per-request hook this is microseconds and dominated by
+  the ARES/VIES network calls — judged negligible.
+- The seam introduces an internal contract (the `$input` array). It is documented in the
+  function docblock but not type-enforced (procedural PHP, by choice).
+- A `bad_format` result is interpreted differently per call site (DIČ branch re-expands to two
+  codes; IČ-DPH branch folds to one). This asymmetry is inherited from the original two-vs-one
+  validator-call behavior and is documented at both sites.
+
+## Verification
+
+- `composer test:unit` — green (new `ValidationTest` + existing `Helpers`/`Ares`).
+- No build step applies (gulp builds only CSS/JS; PHP is not bundled).
+- **Outstanding manual step:** a live-checkout smoke test confirming identical message text,
+  order, and count for: CZ bad IČ; CZ ARES mismatch (ares_fill on); SK mismatched DIČ/IČ-DPH;
+  EU malformed VAT (expect both `vat_format` + `invalid_vat`); EU VIES-unverifiable with
+  ignore-check-fail on/off. Not runnable in CI (needs WooCommerce + network).
+
+## Notes for future work
+
+- This was **candidate 1** of the architecture review. Candidate 3 (the two VAT-exempt twins,
+  `set_vat_exempt_for_customer` / `validate_vat_exempt_for_company`) should reuse the
+  `verify_vat` seam established here. Candidate 5 (`ares.php` parse/transport split and its
+  pre-translated error strings) remains untouched — its `error` string is passed through
+  verbatim as `data` for now.

--- a/docs/plans/candidate-1-validation-orchestrator.md
+++ b/docs/plans/candidate-1-validation-orchestrator.md
@@ -1,0 +1,150 @@
+# Plan — Deepen the checkout validation orchestrator (Candidate 1)
+
+**Status:** designed, ready to implement
+**Date:** 2026-06-26
+**Source:** architecture review `~/Development/_ai/architecture-review/kybernaut-ic-dic-20260626.html`, candidate 1
+**Recommendation strength:** Strong
+
+## Goal
+
+`woolab_icdic_checkout_field_process()` (`includes/filters-actions.php:153–376`) is the plugin's
+central business logic — all CZ/SK/EU validation — fused into one `woocommerce_checkout_process`
+hook callback with no return value, driven off `$_POST` / `wc_add_notice()` / `WC()->session`.
+It has **zero tests** and is the single largest untested risk surface.
+
+**Deepen it:** extract the decision into a pure module behind one interface; leave the hook as a
+thin adapter. Same frontend behavior, but the branching becomes testable through its interface.
+
+This is a **behavior-preserving refactor**. No frontend/notice changes.
+
+## Scope
+
+- **In:** `woolab_icdic_checkout_field_process()` only.
+- **Out (later candidates):**
+  - The two VAT-exempt twins (`set_vat_exempt_for_customer`, `validate_vat_exempt_for_company`) →
+    **candidate 3**. Design the VIES seam here so candidate 3 can reuse it.
+  - `ares.php` parse/transport split and its pre-translated error strings → **candidate 5**.
+    Leave `ares.php` untouched; pass its `error` string through verbatim as `data`.
+
+## Design decisions (from grilling)
+
+1. **Output = structured error codes**, not translated strings. The pure module returns codes;
+   the adapter renders them to `wc_add_notice()`. Tests assert on codes, never English text.
+
+2. **One pure function**, not interface classes (proportionate to a procedural PHP 7.3 plugin):
+
+   ```php
+   woolab_icdic_validate_checkout( array $input ): array
+   ```
+
+3. **Network crosses the seam as plain closures** passed in `$input` — no DI container, no
+   interface classes. Real closure in prod, fake closure in tests (= two adapters, real seam).
+
+4. **Config resolved by the adapter, passed in as plain booleans.** The pure function reads no
+   settings/filters/options. Every `apply_filters` / `get_option` / settings helper fires **from
+   the adapter, unchanged** — same hook names, defaults, args, WordPress context. Chosen
+   **Option A** (resolve filters once up front); the zero-arg config filters make this
+   behaviorally identical.
+
+5. **New file `includes/validation.php`**, added to the test bootstrap alongside `helpers.php`.
+   Keeps pure orchestration distinct from the math primitives in `helpers.php`.
+
+6. **Error entries carry data:** `['code' => '...', 'data' => [...]]`; `data` omitted when unused.
+
+7. **`verify_vat` closure returns a four-state string**, keeping ibericode (`Validator`,
+   `ViesException`) 100% behind the seam — the pure function never references it:
+   - `valid` | `bad_format` | `invalid` | `unverifiable` (`unverifiable` = `ViesException` caught
+     inside the closure; VIES logging stays in the adapter's closure).
+
+8. **`lookup_ares` closure returns the raw `woolab_icdic_ares()` array**; the pure function owns
+   all cross-checking (field mismatch → `missing_fields`) and the `internal_error`/`ignore` paths.
+
+9. **Preserve existing quirks, do not "fix" them** as part of this refactor (e.g. the early
+   `return false` at line 156 when `billing_country` is unset *skips* setting the session flag —
+   keep it). Any fix is a separate change after the refactor lands.
+
+## Interface
+
+```php
+/**
+ * Pure validation of the company-identifier checkout fields.
+ * No WordPress, no WooCommerce, no network, no i18n.
+ */
+woolab_icdic_validate_checkout( array $input ): array
+
+// $input keys:
+//   values:   country, ic, dic, dic_dph, company, postcode, city, address_1,
+//             ship_to_different (bool), shipping_country
+//   flags:    ares_check, ares_fill, vies_check, ignore_check_fail,
+//             check_country_match, require_sk_ic_and_dic, check_dic_dph_match
+//   closures: verify_vat  : fn(string $vat): string  // 'valid'|'bad_format'|'invalid'|'unverifiable'
+//             lookup_ares  : fn(string $ico): array   // raw woolab_icdic_ares() result (or falsy)
+//
+// returns:
+//   [
+//     'errors' => [ ['code' => string, 'data' => array], ... ],  // in current emission order
+//     'check_fail_ignored' => bool,
+//   ]
+```
+
+### Error codes → existing notices (verbatim mapping, owned by the adapter)
+
+| code | data | current string (text domain) | context |
+|------|------|------------------------------|---------|
+| `invalid_business_id` | `ares_message?` | `Enter a valid Business ID` (`woolab-ic-dic`) + ARES msg | IC block |
+| `ares_unexpected` | – | `Unexpected error occurred. Try it again.` (`woolab-ic-dic`) | IC, ARES falsy |
+| `ares_mismatch` | `fields[]` | `_n('%s is not corresponding to ARES.', '%s are not corresponding to ARES.', n, 'woolab-ic-dic')` via `wc_format_list_of_items` | IC, ares_fill |
+| `vat_country_mismatch_billing` | – | `The billing country does not correspond to the country of the VAT number.` (`woolab-ic-dic`) | DIČ + IC DPH |
+| `vat_country_mismatch_shipping` | – | `The shipping country does not correspond to the country of the VAT number.` (`woolab-ic-dic`) | DIČ |
+| `vat_format` | – | `VAT number has not correct format` (`woolab-ic-dic`) | DIČ |
+| `invalid_vat` | – | `Enter a valid VAT number` (`woolab-ic-dic`) | DIČ |
+| `vat_unverifiable` | – | `Could not validate VAT number.` (`woolab-ic-dic`) | DIČ + IC DPH |
+| `invalid_dic_cz` | – | `Enter a valid VAT number` (`woolab-ic-dic`) | DIČ, CZ math path |
+| `invalid_tax_id_sk` | – | `Enter a valid Tax ID` (`woolab-ic-dic`) | DIČ SK math + SK required |
+| `invalid_vat_dph` | – | `_x('Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic')` | IC DPH |
+| `dic_dph_mismatch` | – | `Tax ID or VAT number is not valid.` (`woolab-ic-dic`) | IC DPH match check |
+
+> Codes split where the same English string is emitted from different branches with different
+> contexts (`invalid_vat` vs `invalid_dic_cz` vs `invalid_vat_dph`) so tests can tell branches
+> apart; the adapter maps each back to its exact original string + context.
+
+## Implementation steps
+
+1. **Characterization tests first.** New `tests/unit/ValidationTest.php`. Drive
+   `woolab_icdic_validate_checkout()` across every branch (CZ ARES on/off, CZ math, SK IČ/DIČ,
+   SK IC DPH VIES on/off, country-prefix mismatches, ignore-check-fail paths, DIČ/IČ-DPH match)
+   asserting the returned `errors` codes + `check_fail_ignored`. Pure — **no WP_Mock needed**.
+   Use fake closures: `fn($v) => 'unverifiable'`, `fn($ico) => [...]`.
+
+2. **Write `includes/validation.php`** — the pure `woolab_icdic_validate_checkout()`. Port the
+   branching from lines 168–371 verbatim in logic and order; replace `wc_add_notice(...)` with
+   pushing `['code'=>..., 'data'=>...]`, replace settings/filter reads with `$input` flags,
+   replace `Validator`/`woolab_icdic_ares()` calls with `$input['verify_vat']`/`['lookup_ares']`,
+   replace the session write with the returned `check_fail_ignored`.
+
+3. **Add `includes/validation.php` to the test bootstrap** (`tests/bootstrap.php`) next to
+   `helpers.php` / `ares.php`.
+
+4. **Rewrite the hook as the adapter** in `includes/filters-actions.php`:
+   - clean `$_POST` into the values,
+   - resolve every setting/filter/option into the flags (Option A, once up front),
+   - build the two closures (the `verify_vat` closure logs `ViesException` then returns
+     `unverifiable`; the `lookup_ares` closure wraps `woolab_icdic_ares()`),
+   - call `woolab_icdic_validate_checkout()`,
+   - map each returned code → exact original `wc_add_notice()` string/domain/context,
+   - `WC()->session->set('woolab_icdic_vat_check_fail_ignored', $result['check_fail_ignored'])`,
+   - preserve the early `return` (and its skipped-flag quirk) when `billing_country` is unset.
+
+5. **Verify (build + behavior):**
+   - `composer test:unit` green (new ValidationTest + existing Helpers/Ares).
+   - Manual checkout smoke test: CZ bad IČ, CZ ARES mismatch, SK mismatched DIČ/IČ-DPH, EU VIES
+     unverifiable with ignore on/off — confirm identical messages, order, and count to current.
+
+## Risks / guardrails
+
+- **Frontend:** only the adapter can break it (a notice not reproduced exactly). Mitigated by the
+  verbatim mapping table above + characterization tests + manual smoke test.
+- **`public.js` ARES autofill** is a separate path — untouched.
+- **Extension filters** fire from the adapter, unchanged — no public API change.
+- **Reuse:** the four-state `verify_vat` seam and the SK→`dic_dph`-else-`dic` selection are
+  carried forward to candidate 3.

--- a/docs/plans/candidate-2-settings-read-seam.md
+++ b/docs/plans/candidate-2-settings-read-seam.md
@@ -1,0 +1,87 @@
+# Plan — One settings module, one read seam (Candidate 2)
+
+**Status:** designed, ready to implement (after candidates 1 & 3)
+**Date:** 2026-06-26
+**Source:** architecture review `kybernaut-ic-dic-20260626` candidate 2
+**Recommendation strength:** Strong
+
+## Goal
+
+`settings.php` defines 8 option keys, but they are read in **two incompatible styles**: four go
+through helper accessors (`woolab_icdic_ares_check/ares_fill/vies_check/ignore_check_fail` in
+`woolab-ic-dic.php:157–182`, each normalizing via `woolab_icdic_get_option()` = `option == 'yes'`),
+while four more are read raw with the `'yes'/'no'` truthiness and the `wc_tax_enabled()` clause
+**hand-copied at each call site**. `woolab_icdic_vat_exempt_switch` is byte-identical at two sites.
+
+Promote the four raw reads into named accessors so every settings read crosses one interface and
+the normalization lives in exactly one place per option.
+
+## The four raw reads (current)
+
+| Option | Site(s) | Current expression | Filter arg shape |
+|--------|---------|--------------------|------------------|
+| `vat_exempt_switch` | `filters-actions.php:398`, `:430` | `apply_filters('woolab_icdic_vat_exempt_enabled', get_option(..,'no') !== 'no' && wc_tax_enabled())` | **bool** |
+| `disable_dic_dicdph_match` | `filters-actions.php:223` | `apply_filters('woolab_icdic_enable_dic_dicdph_match_check', get_option(..,'no') !== 'yes')` | **bool** |
+| `toggle_switch` | `filters-actions.php:62` (fields), `woolab-ic-dic.php:152` (css) | `apply_filters('woolab_icdic_toggle', get_option(..,'no'))` then `!== 'no'` *vs* `=== 'yes'` | **string** |
+| `country_switch` | `filters-actions.php:88` | `apply_filters('woolab_icdic_country_ontop', get_option(..,'no'))` then `!== 'no'` | **string** |
+
+## Decision — preserve filter contracts; centralize only normalization
+
+New accessors (placed next to the existing four helpers in `woolab-ic-dic.php`), each returning
+`bool` and keeping the **existing filter name and argument shape** so no public filter breaks:
+
+```php
+woolab_icdic_vat_exempt_enabled()         // apply_filters('woolab_icdic_vat_exempt_enabled', get_option('woolab_icdic_vat_exempt_switch','no') !== 'no' && wc_tax_enabled())
+woolab_icdic_dic_dicdph_match_enabled()   // apply_filters('woolab_icdic_enable_dic_dicdph_match_check', get_option('woolab_icdic_disable_dic_dicdph_match','no') !== 'yes')
+woolab_icdic_toggle_enabled()             // apply_filters('woolab_icdic_toggle', get_option('woolab_icdic_toggle_switch','no')) !== 'no'
+woolab_icdic_country_ontop_enabled()      // apply_filters('woolab_icdic_country_ontop', get_option('woolab_icdic_country_switch','no')) !== 'no'
+```
+
+The `vat_exempt`/`dicdph` filters keep receiving a **bool** (unchanged); the `toggle`/`country`
+filters keep receiving the **string** option and the `!== 'no'` normalization happens after the
+filter (unchanged for those two functional sites).
+
+### One flagged nuance (behavior-identical for every settings-UI value)
+
+The toggle option is currently read with two different comparisons:
+- `filters-actions.php:62` (adds the company checkbox + toggle field classes): `!== 'no'`
+- `woolab-ic-dic.php:152` (enqueues `style.css`): `=== 'yes'`
+
+Both accessor call sites will use `woolab_icdic_toggle_enabled()` = `!== 'no'`. This standardizes
+the CSS-enqueue site from `=== 'yes'` to `!== 'no'`. The settings checkbox only ever stores
+`'yes'` or `'no'`, and the `woolab_icdic_toggle` filter defaults to passing that through, so the
+two are **identical for every configuration the UI can produce**. They diverge only if a
+third-party filter returns some other truthy string — in which case the CSS now loads whenever the
+toggle fields are shown, which is the consistent (and arguably correct) outcome. Documented here
+and in the commit so it is not a silent change.
+
+## Implementation steps
+
+1. Add the four accessors in `woolab-ic-dic.php`, immediately after
+   `woolab_icdic_ignore_check_fail()`.
+2. Replace the call sites:
+   - `filters-actions.php:62` → `if ( woolab_icdic_toggle_enabled() ) {`  (drop `$woolabToggle`)
+   - `filters-actions.php:88` → `if ( woolab_icdic_country_ontop_enabled() ) {`  (drop `$countryFirst`)
+   - `filters-actions.php:223` → `'check_dic_dph_match' => woolab_icdic_dic_dicdph_match_enabled(),`
+   - `filters-actions.php:398` & `:430` → `$enabled = woolab_icdic_vat_exempt_enabled();`
+   - `woolab-ic-dic.php:152` → `if ( woolab_icdic_toggle_enabled() ) { wp_enqueue_style(...) }`
+3. `composer test:unit` green (no test depends on these; existing suite must stay green).
+4. Manual smoke: with the company toggle ON, confirm the checkout still shows the
+   company checkbox + IČ/DIČ fields and the toggle CSS still loads; confirm VAT exemption and the
+   DIČ/IČ-DPH match check still behave as before.
+
+## Scope
+
+- **In:** the four raw settings reads above and their five call sites.
+- **Out:** the existing four helpers (already correct), the `woolab_icdic_notice_settings` admin
+  notice option (unrelated dismissal flag), the field registry (candidate 4), `ares.php`
+  (candidate 5). No settings UI / option storage changes.
+
+## Risks / guardrails
+
+- **Public filters unchanged** — same names, same argument types; extensions keep working.
+- The single nuance (CSS-enqueue comparison) is behavior-identical for all UI-producible values
+  and documented above.
+- No unit-test surface (these are WordPress option reads); covered by the existing suite staying
+  green plus the manual toggle smoke test.
+```

--- a/docs/plans/candidate-3-vat-exempt-module.md
+++ b/docs/plans/candidate-3-vat-exempt-module.md
@@ -1,0 +1,138 @@
+# Plan — Collapse the two VAT-exemption twins into one module (Candidate 3)
+
+**Status:** designed, ready to implement (after candidate 1 — landed in `47818e8`)
+**Date:** 2026-06-26
+**Source:** architecture review `kybernaut-ic-dic-20260626` candidate 3
+**Recommendation strength:** Strong
+
+## Goal
+
+`woolab_icdic_set_vat_exempt_for_customer()` (`includes/filters-actions.php:376–422`, hooked on
+`init`) and `woolab_icdic_validate_vat_exempt_for_company()` (`:424–477`, hooked on
+`woocommerce_checkout_update_order_review`) carry a **near-identical VIES + exemption body**. The
+inner decision (`validateVatNumberFormat` → `validateVatNumber` → `ViesException` →
+`ignore_check_fail ? true : false`) and the **SK→`dic_dph` else `dic`** number-selection rule are
+duplicated between them — and the selection rule appears a *third* time in candidate 1.
+
+A customer-facing VAT-exemption bug must currently be fixed in two places that can drift.
+
+**Deepen it:** extract one pure exemption decision behind the **same `verify_vat` seam built in
+candidate 1**; the two hooks stay as thin adapters that gate, source data, select the VAT number,
+and apply the result. Behavior-preserving.
+
+## What is actually shared vs different (verified against current source)
+
+The review calls these "the same logic twice", but they are **near**-identical — the refactor must
+preserve the differences, not erase them:
+
+| Aspect | `set_..._customer` (init) | `validate_..._company` (order_review) |
+|--------|---------------------------|----------------------------------------|
+| Bail early | `wp_doing_ajax()` → return | — |
+| Enabled gate | `vat_exempt_enabled` filter + `vat_exempt_switch != 'no'` + `wc_tax_enabled()` | **same** (byte-identical) |
+| Data source | `$customer->get_meta('billing_*')` | `wp_parse_str($post_data)` → `$data['billing_*']` |
+| Country gate | `billing_country` non-empty **and != base_country** | empty / == base / **not in `eu_vat`** → return |
+| EU-membership check | **absent** | present (`get_european_union_countries('eu_vat')`) |
+| `is_company` check | **absent** | `!isset(billing_iscomp) \|\| billing_iscomp == 1` |
+| VAT selection | SK→`dic_dph` else `dic` | **same** |
+| VIES decision body | shared (see below) | **same** |
+| Logger message | `'Could not validate if VAT number is exempt: %s…'` | **same** |
+| Result filter | `woolab_icdic_vat_exempt_customer` ($exempt, $vat, $customer) | `woolab_icdic_vat_exempt_company` ($exempt, $data) |
+| Apply | `$customer->set_is_vat_exempt(...)` | `WC()->customer->set_is_vat_exempt(...)`; else-branch sets `false` |
+
+**Genuinely shared core (the only thing to extract):**
+
+```php
+$is_vat_exempt = false;
+if ( $validator->validateVatNumberFormat( $vat_num ) ) {
+    try { $is_vat_exempt = $validator->validateVatNumber( $vat_num ); }
+    catch ( ViesException $e ) { /* log */ $is_vat_exempt = $ignore_check_fail; }   // false otherwise
+}
+```
+
+Mapped onto candidate 1's four-state `verify_vat`:
+`valid → true`, `unverifiable → $ignore_check_fail`, `bad_format | invalid → false`.
+
+## Design
+
+1. **Reuse the candidate-1 VIES seam — land it once.** The inline `$verify_vat` closure currently
+   built inside `woolab_icdic_checkout_field_process()` (`includes/filters-actions.php`) is
+   promoted to a small factory so all three call sites share one construction:
+
+   ```php
+   // includes/validation.php (or a thin helper) — adapter-side, NOT pure
+   function woolab_icdic_make_vies_verifier( string $log_message ): callable
+   // returns fn(string $vat): string  // 'valid'|'bad_format'|'invalid'|'unverifiable'
+   ```
+
+   `$log_message` is the `sprintf` format the closure logs on `ViesException` — this is the one
+   difference between candidate 1 (`'Could not validate VAT number: %s…'`) and the exemption path
+   (`'Could not validate if VAT number is exempt: %s…'`), so it stays parameterized to preserve
+   logs verbatim. Candidate 1's adapter switches to this factory (no behavior change).
+
+2. **One pure decision** in `includes/validation.php`:
+
+   ```php
+   /** valid → true; unverifiable → $ignore_check_fail; bad_format|invalid → false */
+   function woolab_icdic_vat_exempt_from_state( string $state, bool $ignore_check_fail ): bool
+   ```
+
+   Plus the shared selection rule (already implicit in candidate 1):
+
+   ```php
+   function woolab_icdic_select_vat_number( string $country, string $dic, string $dic_dph ): string
+   // $country === 'SK' ? $dic_dph : $dic
+   ```
+
+   Both pure, no WP/network/i18n — unit-tested directly.
+
+3. **The two hooks become adapters.** Each keeps its own gating (ajax bail / EU check /
+   `is_company` / data source / result filter / apply target — all unchanged), and for the inner
+   decision does:
+
+   ```php
+   $vat_num = woolab_icdic_select_vat_number( $country, $dic, $dic_dph );
+   $is_vat_exempt = false;
+   if ( ! empty( $vat_num ) ) {
+       $state = $verify_vat( $vat_num );                       // shared factory closure
+       $is_vat_exempt = woolab_icdic_vat_exempt_from_state( $state, $ignore_check_fail );
+   }
+   // ... existing apply_filters + set_is_vat_exempt unchanged
+   ```
+
+   The `! empty( $vat_num )` guard preserves the original "don't touch the validator when no VAT
+   number" path (and avoids a wasted `Validator` construction).
+
+## Scope
+
+- **In:** `set_vat_exempt_for_customer`, `validate_vat_exempt_for_company`, and promoting the
+  candidate-1 `verify_vat` closure to a shared factory.
+- **Out:** the country-gating differences themselves (kept verbatim — this is not the place to
+  reconcile whether the customer path *should* also check EU membership; that is a separate,
+  behavior-changing decision). `ares.php` (candidate 5). The field registry (candidate 4).
+
+## Implementation steps (TDD)
+
+1. **Tests first** — extend `tests/unit/ValidationTest.php` (or a new `VatExemptTest.php`):
+   - `woolab_icdic_vat_exempt_from_state`: `valid→true`, `invalid→false`, `bad_format→false`,
+     `unverifiable` with `$ignore` true→true and false→false.
+   - `woolab_icdic_select_vat_number`: SK→dic_dph, CZ/other→dic, empties.
+2. **Add the two pure functions** to `includes/validation.php`.
+3. **Add the verifier factory** `woolab_icdic_make_vies_verifier()`; point candidate 1's adapter at
+   it (confirm `composer test:unit` still green — candidate 1 behavior unchanged).
+4. **Rewrite both hooks** to use the factory + the two pure functions, preserving every gate,
+   filter, log message, and apply target exactly.
+5. **Verify:** `composer test:unit` green; manual smoke — set base country, then a B2B EU order
+   with a valid VIES number (tax removed), an invalid one (tax kept), and VIES-down with
+   ignore-check-fail on/off; confirm exemption state matches current on both the `init` and
+   `update_order_review` paths.
+
+## Risks / guardrails
+
+- **Behavior drift between the twins is intentional and must survive** (EU check, `is_company`).
+  The extracted core is only the VIES decision + selection; everything else stays in the adapter.
+- **Log strings** differ from candidate 1 — preserved via the factory's `$log_message` param.
+- **`ViesException` must stay swallowed** (never re-thrown): an uncaught exception on `init` /
+  checkout AJAX would fatal the request when VIES is down. The factory keeps the catch internal.
+- Shared verifier factory is built per-request inside each adapter (empty `use`), so no
+  large-scope capture / memory concern.
+```

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -149,6 +149,39 @@ function woolab_icdic_billing_fields( $fields, $country ) {
 	return woolab_icdic_add_after_company( $fields, $additional_fields, 'billing' );
 }
 
+/**
+ * Build the VIES verification closure shared by the checkout-validation and
+ * VAT-exemption hooks. Keeps the ibericode Validator/ViesException behind a seam
+ * and collapses validation into the four-state string the pure modules consume
+ * ('valid'|'bad_format'|'invalid'|'unverifiable').
+ *
+ * $log_message is the sprintf format logged (with the VAT number) when VIES is
+ * unreachable. It differs per call site — the checkout path and the exemption
+ * path used distinct wording — so it stays parameterized to preserve the
+ * original log output verbatim.
+ *
+ * @param string $log_message sprintf format with a single %s for the VAT number.
+ * @return callable fn(string $vat): string
+ */
+function woolab_icdic_make_vies_verifier( $log_message ) {
+	return function ( $vat ) use ( $log_message ) {
+		$validator = new Validator();
+
+		if ( ! $validator->validateVatNumberFormat( $vat ) ) {
+			return 'bad_format';
+		}
+
+		try {
+			return $validator->validateVatNumber( $vat ) ? 'valid' : 'invalid';
+		} catch ( ViesException $exception ) {
+			$logger = Logger::getInstance();
+			$logger->log( sprintf( $log_message, $vat ) );
+			$logger->log( $exception );
+			return 'unverifiable';
+		}
+	};
+}
+
 // check field on checkout
 //
 // Thin adapter: cleans $_POST, resolves all settings/filters/options into plain
@@ -165,24 +198,7 @@ function woolab_icdic_checkout_field_process() {
 
 	$country = wc_clean( wp_unslash( $_POST['billing_country'] ) );
 
-	// VIES validation closure. Keeps the ibericode Validator/ViesException behind
-	// the seam and collapses validation into a four-state string for the pure module.
-	$verify_vat = function ( $vat ) {
-		$validator = new Validator();
-
-		if ( ! $validator->validateVatNumberFormat( $vat ) ) {
-			return 'bad_format';
-		}
-
-		try {
-			return $validator->validateVatNumber( $vat ) ? 'valid' : 'invalid';
-		} catch ( ViesException $exception ) {
-			$logger = Logger::getInstance();
-			$logger->log( sprintf( 'Could not validate VAT number: %s, returned the following exception:', $vat ) );
-			$logger->log( $exception );
-			return 'unverifiable';
-		}
-	};
+	$verify_vat = woolab_icdic_make_vies_verifier( 'Could not validate VAT number: %s, returned the following exception:' );
 
 	$countries = new Countries();
 
@@ -391,29 +407,18 @@ function woolab_icdic_set_vat_exempt_for_customer() {
 	$base_country          = apply_filters( 'woolab_icdic_base_country', $base_country );
 	$ignore_vat_check_fail = woolab_icdic_ignore_check_fail();
 	$is_vat_exempt         = false;
+	$billing_country       = $customer->get_meta('billing_country');
 
-	if (!empty($customer->get_meta('billing_country')) && $customer->get_meta('billing_country') !== $base_country) {
-		$vat_num = $customer->get_meta('billing_country') == 'SK' ? $customer->get_meta('billing_dic_dph') : $customer->get_meta('billing_dic');
+	if (!empty($billing_country) && $billing_country !== $base_country) {
+		$vat_num = woolab_icdic_select_vat_number( $billing_country, $customer->get_meta('billing_dic'), $customer->get_meta('billing_dic_dph') );
 	}
 
 	if (!empty($vat_num)) {
-		$validator = new Validator();
-		if ( $validator->validateVatNumberFormat( $vat_num ) ) {
-			try {
-				$is_vat_exempt = $validator->validateVatNumber( $vat_num );
-			} catch ( ViesException $exception ) {
-				$logger = Logger::getInstance();
-				$logger->log(sprintf('Could not validate if VAT number is exempt: %s, returned the following exception:', $vat_num));
-				$logger->log($exception);
-				if ( $ignore_vat_check_fail ) {
-					$is_vat_exempt = true;
-				} else {
-					// Don't re-throw: an uncaught exception here would fatal the
-					// whole request (init / checkout AJAX) whenever VIES is down.
-					$is_vat_exempt = false;
-				}
-			}
-		}
+		// VIES outage must never re-throw here: an uncaught exception on init /
+		// checkout AJAX would fatal the whole request whenever VIES is down. The
+		// verifier swallows it and returns 'unverifiable'.
+		$verify_vat    = woolab_icdic_make_vies_verifier( 'Could not validate if VAT number is exempt: %s, returned the following exception:' );
+		$is_vat_exempt = woolab_icdic_vat_exempt_from_state( $verify_vat( $vat_num ), $ignore_vat_check_fail );
 	}
 
 	$is_vat_exempt = apply_filters( 'woolab_icdic_vat_exempt_customer', $is_vat_exempt, $vat_num, $customer );
@@ -443,30 +448,16 @@ function woolab_icdic_validate_vat_exempt_for_company( $post_data ) {
 		return;
 	}
 
-	$vat_num = $country === 'SK' ? ( isset( $data['billing_dic_dph'] ) ? $data['billing_dic_dph'] : '' ) : ( isset( $data['billing_dic'] ) ? $data['billing_dic'] : '' );
+	$vat_num = woolab_icdic_select_vat_number( $country, isset( $data['billing_dic'] ) ? $data['billing_dic'] : '', isset( $data['billing_dic_dph'] ) ? $data['billing_dic_dph'] : '' );
 
 	$is_company = ! isset($data['billing_iscomp']) || $data['billing_iscomp'] == 1;
 
 	if ( !empty($vat_num) && $is_company ) {
-		$validator     = new Validator();
-		$is_vat_exempt = false;
-
-		if ( $validator->validateVatNumberFormat( $vat_num ) ) {
-			try {
-				$is_vat_exempt = $validator->validateVatNumber( $vat_num );
-			} catch ( ViesException $exception ) {
-				$logger = Logger::getInstance();
-				$logger->log(sprintf('Could not validate if VAT number is exempt: %s, returned the following exception:', $vat_num));
-				$logger->log($exception);
-				if ( $ignore_vat_check_fail ) {
-					$is_vat_exempt = true;
-				} else {
-					// Don't re-throw: an uncaught exception here would fatal the
-					// whole request (init / checkout AJAX) whenever VIES is down.
-					$is_vat_exempt = false;
-				}
-			}
-		}
+		// VIES outage must never re-throw here: an uncaught exception on
+		// checkout AJAX would fatal the whole request whenever VIES is down. The
+		// verifier swallows it and returns 'unverifiable'.
+		$verify_vat    = woolab_icdic_make_vies_verifier( 'Could not validate if VAT number is exempt: %s, returned the following exception:' );
+		$is_vat_exempt = woolab_icdic_vat_exempt_from_state( $verify_vat( $vat_num ), $ignore_vat_check_fail );
 
 		$is_vat_exempt = apply_filters( 'woolab_icdic_vat_exempt_company', $is_vat_exempt, $data );
 

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -150,229 +150,142 @@ function woolab_icdic_billing_fields( $fields, $country ) {
 }
 
 // check field on checkout
+//
+// Thin adapter: cleans $_POST, resolves all settings/filters/options into plain
+// flags, builds the two network closures (ARES + VIES), delegates the decision
+// to the pure orchestrator woolab_icdic_validate_checkout() (includes/validation.php),
+// then maps the returned structured error codes back to the exact original notices.
 function woolab_icdic_checkout_field_process() {
 
 	// Bail if form not fully filled.
+	// NOTE: this early return also skips writing the session flag below — preserved on purpose.
 	if (!isset($_POST['billing_country'])) {
 		return false;
 	}
 
-	$country               = wc_clean( wp_unslash( $_POST['billing_country'] ) );
-	$ignore_vat_check_fail = woolab_icdic_ignore_check_fail();
+	$country = wc_clean( wp_unslash( $_POST['billing_country'] ) );
 
-	// Flag to check if VAT check fail was ignored.
-	// The information will be saved in the order meta in woocommerce_new_order hook.
-	$vat_check_fail_ignored = false;
+	// VIES validation closure. Keeps the ibericode Validator/ViesException behind
+	// the seam and collapses validation into a four-state string for the pure module.
+	$verify_vat = function ( $vat ) {
+		$validator = new Validator();
 
-	// BUSINESS ID
-	if ( isset( $_POST['billing_ic'] ) && $_POST['billing_ic'] ) {
-
-		/**
-		 * Remove white spaces
-		 * @since 1.4.0
-		 */
-		$ico = preg_replace('/\s+/', '', wc_clean( wp_unslash( $_POST['billing_ic'] ) ) );
-
-		// CZ
-		if ( $country == "CZ" ) {
-
-			// ARES Check Enabled
-			if ( woolab_icdic_ares_check() ) {
-
-				$ares = woolab_icdic_ares( $ico  );
-				if ( $ares ) {
-					if ( $ares['error'] ) {
-						$is_internal_error = ( ! empty( $ares['internal_error'] ) );
-
-						if ( $is_internal_error && $ignore_vat_check_fail ) {
-							$vat_check_fail_ignored = true;
-						} else {
-							wc_add_notice( __( 'Enter a valid Business ID', 'woolab-ic-dic' ) . ' ' . $ares['error'], 'error' );
-						}
-					} elseif ( woolab_icdic_ares_fill() ) {
-						if ( isset( $_POST['billing_dic'] ) && wc_clean( wp_unslash($_POST['billing_dic'])) != $ares['dic'] ) {
-							$missing_fields[] = __( 'Tax ID', 'woolab-ic-dic' );
-						}
-						if ( wc_clean( wp_unslash( $_POST['billing_company'] ?? '' ) ) != $ares['spolecnost'] ) {
-							$missing_fields[] = __( 'Company', 'woocommerce' );
-						}
-						if ( wc_clean( wp_unslash($_POST['billing_postcode'])) != $ares['psc'] ) {
-							$missing_fields[] = __( 'Postcode / ZIP', 'woocommerce' );
-						}
-						if ( wc_clean( wp_unslash($_POST['billing_city'])) != $ares['mesto'] ) {
-							$missing_fields[] = __( 'Town / City', 'woocommerce' );
-						}
-						if ( wc_clean( wp_unslash($_POST['billing_address_1'])) != $ares['adresa'] ) {
-							$missing_fields[] = __( 'Address', 'woocommerce' );
-						}
-						if ( isset( $missing_fields ) ) {
-							wc_add_notice( sprintf( _n( '%s is not corresponding to ARES.', '%s are not corresponding to ARES.', count( $missing_fields ), 'woolab-ic-dic' ), wc_format_list_of_items( $missing_fields ) ), 'error' );
-						}
-					}
-				} else {
-					if ( $ignore_vat_check_fail ) {
-						$vat_check_fail_ignored = true;
-					} else {
-						wc_add_notice( __( 'Unexpected error occurred. Try it again.', 'woolab-ic-dic' ), 'error' );
-					}
-				}
-
-			// ARES Check Disabled
-			} elseif ( ! woolab_icdic_verify_ic( $ico )) {
-					wc_add_notice( __( 'Enter a valid Business ID', 'woolab-ic-dic'  ), 'error' );
-			}
-
-		// SK
-		} elseif ( $country == "SK" ) {
-			if ( $ico ) {
-				if ( ! woolab_icdic_verify_ic( $ico )) {
-					wc_add_notice( __( 'Enter a valid Business ID', 'woolab-ic-dic'  ), 'error' );
-				}
-			}
+		if ( ! $validator->validateVatNumberFormat( $vat ) ) {
+			return 'bad_format';
 		}
 
-	}
-
-	// VAT / DIC
-	if ( isset( $_POST['billing_dic'] ) && $_POST['billing_dic'] ) {
-
-		/**
-		 * Remove white spaces
-		 * @since 1.4.0
-		 */
-
-		$dic = preg_replace('/\s+/', '', wc_clean( wp_unslash( $_POST['billing_dic'] ) ) );
-		$countries = new Countries();
-
-
-		// Check if in EU
-		if ( $countries->isCountryCodeInEU( $country ) ) {
-
-			// If Validate in VIES
-			// Slovak DIC cannot (and shouldn't) be validated in VIES
-			if ( woolab_icdic_vies_check() && $country != 'SK' ) {
-
-				// Match VAT country prefix and country code.
-				// @since 1.7.3.
-				if ( apply_filters( 'woolab_icdic_check_billing_country_and_dic', true ) && woolab_icdic_get_vat_number_country_code($dic) !== $country ) {
-					wc_add_notice( __( 'The billing country does not correspond to the country of the VAT number.', 'woolab-ic-dic' ), 'error' );
-				}
-
-				// Match VAT country prefix and shipping country code.
-				// @since 1.10.0.
-				if ( apply_filters( 'woolab_icdic_check_billing_country_and_dic', true ) && ! empty( $_POST['ship_to_different_address'] ) && isset( $_POST['shipping_country'] ) && woolab_icdic_get_vat_number_country_code($dic) !== wc_clean( wp_unslash( $_POST['shipping_country'] ) ) ) {
-					wc_add_notice( __( 'The shipping country does not correspond to the country of the VAT number.', 'woolab-ic-dic' ), 'error' );
-				}
-
-				$validator = new Validator();
-
-				if ( ! $validator->validateVatNumberFormat( $dic )) {
-					wc_add_notice( __( 'VAT number has not correct format', 'woolab-ic-dic' ), 'error' );
-				}
-
-				try {
-					$vat_number_valid = $validator->validateVatNumber( $dic );
-
-					if ( ! $vat_number_valid ) {
-						wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
-					}
-				} catch ( ViesException $exception ) {
-					$logger = Logger::getInstance();
-					$logger->log(sprintf('Could not validate VAT number: %s, returned the following exception:', $dic));
-					$logger->log($exception);
-					if ( $ignore_vat_check_fail ) {
-						$vat_check_fail_ignored = true;
-					} else {
-						wc_add_notice( __( 'Could not validate VAT number.', 'woolab-ic-dic' ), 'error' );
-					}
-				}
-
-			// Validate CZ and SK mathematicaly
-			} else {
-				if ( $country == "CZ" ) {
-					if ( ! ( woolab_icdic_verify_rc( substr( $dic, 2 )) || woolab_icdic_verify_dic( substr( $dic, 2 ) ) ) || substr( $dic, 0, 2) != "CZ") {
-						wc_add_notice( __( 'Enter a valid VAT number', 'woolab-ic-dic' ), 'error' );
-					}
-				} elseif ( $country == "SK" ) {
-
-					if ( ! woolab_icdic_verify_dic_sk( $dic ) ) {
-						wc_add_notice( __( 'Enter a valid Tax ID', 'woolab-ic-dic' ), 'error' );
-					}
-				}
-			}
-
+		try {
+			return $validator->validateVatNumber( $vat ) ? 'valid' : 'invalid';
+		} catch ( ViesException $exception ) {
+			$logger = Logger::getInstance();
+			$logger->log( sprintf( 'Could not validate VAT number: %s, returned the following exception:', $vat ) );
+			$logger->log( $exception );
+			return 'unverifiable';
 		}
+	};
 
-	}
-	// DIC is mandatory in Slovakia, this is not a VAT number
-	else {
-		// if IC is set, DIC must be set as well in Slovakia
-		$required_ic_and_dic = apply_filters( 'woolab_icdic_sk_required_ic_and_dic', true );
-		if( $required_ic_and_dic && !empty( $_POST['billing_ic'] ) && empty( $_POST['billing_dic'] ) && $country == 'SK' ) {
-			wc_add_notice( __( 'Enter a valid Tax ID', 'woolab-ic-dic' ), 'error' );
-		}
-	}
+	$countries = new Countries();
 
-	// IC DPH / DIC DPH
-	if ( isset( $_POST['billing_dic_dph'] ) && $_POST['billing_dic_dph'] && $country == 'SK' ) {
+	$input = array(
+		'country'               => $country,
+		'ic'                    => isset( $_POST['billing_ic'] ) ? wc_clean( wp_unslash( $_POST['billing_ic'] ) ) : '',
+		'dic'                   => isset( $_POST['billing_dic'] ) ? wc_clean( wp_unslash( $_POST['billing_dic'] ) ) : '',
+		'dic_present'           => isset( $_POST['billing_dic'] ),
+		'dic_dph'               => isset( $_POST['billing_dic_dph'] ) ? wc_clean( wp_unslash( $_POST['billing_dic_dph'] ) ) : '',
+		'company'               => wc_clean( wp_unslash( $_POST['billing_company'] ?? '' ) ),
+		'postcode'              => wc_clean( wp_unslash( $_POST['billing_postcode'] ?? '' ) ),
+		'city'                  => wc_clean( wp_unslash( $_POST['billing_city'] ?? '' ) ),
+		'address_1'             => wc_clean( wp_unslash( $_POST['billing_address_1'] ?? '' ) ),
+		'ship_to_different'     => ! empty( $_POST['ship_to_different_address'] ),
+		'shipping_country'      => isset( $_POST['shipping_country'] ) ? wc_clean( wp_unslash( $_POST['shipping_country'] ) ) : null,
+		'ares_check'            => (bool) woolab_icdic_ares_check(),
+		'ares_fill'             => (bool) woolab_icdic_ares_fill(),
+		'vies_check'            => (bool) woolab_icdic_vies_check(),
+		'ignore_check_fail'     => (bool) woolab_icdic_ignore_check_fail(),
+		'check_country_match'   => (bool) apply_filters( 'woolab_icdic_check_billing_country_and_dic', true ),
+		'require_sk_ic_and_dic' => (bool) apply_filters( 'woolab_icdic_sk_required_ic_and_dic', true ),
+		'check_dic_dph_match'   => (bool) apply_filters( 'woolab_icdic_enable_dic_dicdph_match_check', get_option( 'woolab_icdic_disable_dic_dicdph_match', 'no' ) !== 'yes' ),
+		'country_in_eu'         => $countries->isCountryCodeInEU( $country ),
+		'verify_vat'            => $verify_vat,
+		// Raw woolab_icdic_ares() result (or falsy) — passed as a callable directly.
+		'lookup_ares'           => 'woolab_icdic_ares',
+	);
 
-		/**
-		 * Remove white spaces
-		 * @since 1.4.0
-		 */
-		$dic     = preg_replace('/\s+/', '', wc_clean( wp_unslash( $_POST['billing_dic'] ?? '' ) ) );
-		$dic_dph = preg_replace('/\s+/', '', wc_clean( wp_unslash( $_POST['billing_dic_dph'] ) ) );
+	$result = woolab_icdic_validate_checkout( $input );
 
-		// Match VAT country prefix and country code.
-		// @since 1.7.4.
-		if ( apply_filters( 'woolab_icdic_check_billing_country_and_dic', true ) && woolab_icdic_get_vat_number_country_code($dic_dph) !== $country ) {
-			wc_add_notice( __( 'The billing country does not correspond to the country of the VAT number.', 'woolab-ic-dic' ), 'error' );
-		}
-
-		// Verify IC DPH
-		// If Validate in VIES
-		if ( woolab_icdic_vies_check() ) {
-
-			$validator = new Validator();
-
-			try {
-				$vat_number_valid = $validator->validateVatNumber( $dic_dph );
-
-				if ( ! $vat_number_valid ) {
-					wc_add_notice( _x( 'Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic' ), 'error' );
-				}
-			} catch ( ViesException $exception ) {
-				$logger = Logger::getInstance();
-				$logger->log(sprintf('Could not validate VAT number: %s, returned the following exception:', $dic_dph));
-				$logger->log($exception);
-				if ( $ignore_vat_check_fail ) {
-					$vat_check_fail_ignored = true;
-				} else {
-					wc_add_notice( __( 'Could not validate VAT number.', 'woolab-ic-dic' ), 'error' );
-				}
-			}
-
-		} else {
-
-			if ( ! woolab_icdic_verify_dic_dph_sk( $dic_dph ) ) {
-				wc_add_notice( _x( 'Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic' ), 'error' );
-			}
-
-		}
-		
-		// IC DPH has to match to Tax ID number without SK
-		$dic_dicdph_match_enabled = get_option( 'woolab_icdic_disable_dic_dicdph_match', 'no' ) !== 'yes';
-		if ( apply_filters('woolab_icdic_enable_dic_dicdph_match_check', $dic_dicdph_match_enabled) && $dic_dph && $dic ) {
-			if ( $dic != substr( $dic_dph, 2) ) {
-				wc_add_notice( __( 'Tax ID or VAT number is not valid.', 'woolab-ic-dic' ), 'error' );
-			}
-
-		}
+	// Map each structured error code back to its exact original notice.
+	foreach ( $result['errors'] as $error ) {
+		wc_add_notice( woolab_icdic_checkout_error_message( $error ), 'error' );
 	}
 
 	// Set flag about Business ID or VAT number check fails.
-	WC()->session->set( 'woolab_icdic_vat_check_fail_ignored', $vat_check_fail_ignored );
+	// The information will be saved in the order meta in woocommerce_new_order hook.
+	WC()->session->set( 'woolab_icdic_vat_check_fail_ignored', $result['check_fail_ignored'] );
 
+}
+
+/**
+ * Render a structured validation error to its original, translated notice string.
+ *
+ * One-to-one with the codes emitted by woolab_icdic_validate_checkout(); the text,
+ * text domain, and context match the strings the monolithic hook used to emit.
+ *
+ * @param array $error ['code' => string, 'data' => array]
+ * @return string
+ */
+function woolab_icdic_checkout_error_message( array $error ) {
+	switch ( $error['code'] ) {
+		case 'invalid_business_id':
+			$message = __( 'Enter a valid Business ID', 'woolab-ic-dic' );
+			if ( isset( $error['data']['ares_message'] ) ) {
+				$message .= ' ' . $error['data']['ares_message'];
+			}
+			return $message;
+
+		case 'ares_unexpected':
+			return __( 'Unexpected error occurred. Try it again.', 'woolab-ic-dic' );
+
+		case 'ares_mismatch':
+			$labels = array(
+				'tax_id'   => __( 'Tax ID', 'woolab-ic-dic' ),
+				'company'  => __( 'Company', 'woocommerce' ),
+				'postcode' => __( 'Postcode / ZIP', 'woocommerce' ),
+				'city'     => __( 'Town / City', 'woocommerce' ),
+				'address'  => __( 'Address', 'woocommerce' ),
+			);
+			$missing_fields = array();
+			foreach ( $error['data']['fields'] as $field ) {
+				$missing_fields[] = $labels[ $field ];
+			}
+			return sprintf( _n( '%s is not corresponding to ARES.', '%s are not corresponding to ARES.', count( $missing_fields ), 'woolab-ic-dic' ), wc_format_list_of_items( $missing_fields ) );
+
+		case 'vat_country_mismatch_billing':
+			return __( 'The billing country does not correspond to the country of the VAT number.', 'woolab-ic-dic' );
+
+		case 'vat_country_mismatch_shipping':
+			return __( 'The shipping country does not correspond to the country of the VAT number.', 'woolab-ic-dic' );
+
+		case 'vat_format':
+			return __( 'VAT number has not correct format', 'woolab-ic-dic' );
+
+		case 'invalid_vat':
+		case 'invalid_dic_cz':
+			return __( 'Enter a valid VAT number', 'woolab-ic-dic' );
+
+		case 'vat_unverifiable':
+			return __( 'Could not validate VAT number.', 'woolab-ic-dic' );
+
+		case 'invalid_tax_id_sk':
+			return __( 'Enter a valid Tax ID', 'woolab-ic-dic' );
+
+		case 'invalid_vat_dph':
+			return _x( 'Enter a valid VAT number', 'IC DPH', 'woolab-ic-dic' );
+
+		case 'dic_dph_mismatch':
+			return __( 'Tax ID or VAT number is not valid.', 'woolab-ic-dic' );
+	}
+
+	return '';
 }
 
 // My address formatted

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -387,15 +387,31 @@ function woolab_icdic_toggle_iscomp_field($value, $input) {
 	return $value;
 }
 
+/**
+ * Resolve whether a VAT number grants exemption, via the shared VIES seam.
+ *
+ * Wraps the verifier (which swallows VIES outages and returns 'unverifiable' —
+ * it must never re-throw, since an uncaught exception on init / checkout AJAX
+ * would fatal the whole request when VIES is down) and the pure exemption
+ * decision. Shared by both VAT-exempt hooks.
+ *
+ * @param string $vat_num
+ * @param bool   $ignore_check_fail
+ * @return bool
+ */
+function woolab_icdic_vat_number_exempt( $vat_num, $ignore_check_fail ) {
+	$verify_vat = woolab_icdic_make_vies_verifier( 'Could not validate if VAT number is exempt: %s, returned the following exception:' );
+	return woolab_icdic_vat_exempt_from_state( $verify_vat( $vat_num ), $ignore_check_fail );
+}
+
 function woolab_icdic_set_vat_exempt_for_customer() {
 	if ( wp_doing_ajax() ) {
 		return;
 	}
 
-	$customer      = WC()->customer;
-	$enabled       = woolab_icdic_vat_exempt_enabled();
+	$customer = WC()->customer;
 
-	if (empty($customer) || !$enabled) {
+	if ( empty( $customer ) || ! woolab_icdic_vat_exempt_enabled() ) {
 		return;
 	}
 
@@ -412,11 +428,7 @@ function woolab_icdic_set_vat_exempt_for_customer() {
 	}
 
 	if (!empty($vat_num)) {
-		// VIES outage must never re-throw here: an uncaught exception on init /
-		// checkout AJAX would fatal the whole request whenever VIES is down. The
-		// verifier swallows it and returns 'unverifiable'.
-		$verify_vat    = woolab_icdic_make_vies_verifier( 'Could not validate if VAT number is exempt: %s, returned the following exception:' );
-		$is_vat_exempt = woolab_icdic_vat_exempt_from_state( $verify_vat( $vat_num ), $ignore_vat_check_fail );
+		$is_vat_exempt = woolab_icdic_vat_number_exempt( $vat_num, $ignore_vat_check_fail );
 	}
 
 	$is_vat_exempt = apply_filters( 'woolab_icdic_vat_exempt_customer', $is_vat_exempt, $vat_num, $customer );
@@ -425,9 +437,7 @@ function woolab_icdic_set_vat_exempt_for_customer() {
 }
 
 function woolab_icdic_validate_vat_exempt_for_company( $post_data ) {
-	$enabled       = woolab_icdic_vat_exempt_enabled();
-
-	if ( !$enabled ) {
+	if ( ! woolab_icdic_vat_exempt_enabled() ) {
 		return;
 	}
 
@@ -451,11 +461,7 @@ function woolab_icdic_validate_vat_exempt_for_company( $post_data ) {
 	$is_company = ! isset($data['billing_iscomp']) || $data['billing_iscomp'] == 1;
 
 	if ( !empty($vat_num) && $is_company ) {
-		// VIES outage must never re-throw here: an uncaught exception on
-		// checkout AJAX would fatal the whole request whenever VIES is down. The
-		// verifier swallows it and returns 'unverifiable'.
-		$verify_vat    = woolab_icdic_make_vies_verifier( 'Could not validate if VAT number is exempt: %s, returned the following exception:' );
-		$is_vat_exempt = woolab_icdic_vat_exempt_from_state( $verify_vat( $vat_num ), $ignore_vat_check_fail );
+		$is_vat_exempt = woolab_icdic_vat_number_exempt( $vat_num, $ignore_vat_check_fail );
 
 		$is_vat_exempt = apply_filters( 'woolab_icdic_vat_exempt_company', $is_vat_exempt, $data );
 

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -59,8 +59,7 @@ function woolab_icdic_checkout_fields( $fields ) {
 	 * Enable/Disable fields toggle
 	 * @since 1.5.0
 	 */
-	$woolabToggle = apply_filters( 'woolab_icdic_toggle', get_option('woolab_icdic_toggle_switch', 'no') );
-	if($woolabToggle !== 'no') {
+	if( woolab_icdic_toggle_enabled() ) {
 		$fields['billing']['billing_iscomp'] = array(
 			'type'        => 'checkbox',
 			'label_class' => apply_filters( 'woolab_icdic_label_class_billing_iscomp', array('woocommerce-form__label', 'woocommerce-form__label-for-checkbox', 'checkbox') ),
@@ -85,8 +84,7 @@ function woolab_icdic_checkout_fields( $fields ) {
 	 * Move Country above the toggle, makes more sense when filling in VAT / TAX ID
 	 * @since 1.5.0
 	 */
-	$countryFirst = apply_filters( 'woolab_icdic_country_ontop', get_option('woolab_icdic_country_switch', 'no') );
-	if($countryFirst !== 'no') {
+	if( woolab_icdic_country_ontop_enabled() ) {
 		$fields['billing']['billing_country']['priority'] = 28;
 	}
 
@@ -220,7 +218,7 @@ function woolab_icdic_checkout_field_process() {
 		'ignore_check_fail'     => (bool) woolab_icdic_ignore_check_fail(),
 		'check_country_match'   => (bool) apply_filters( 'woolab_icdic_check_billing_country_and_dic', true ),
 		'require_sk_ic_and_dic' => (bool) apply_filters( 'woolab_icdic_sk_required_ic_and_dic', true ),
-		'check_dic_dph_match'   => (bool) apply_filters( 'woolab_icdic_enable_dic_dicdph_match_check', get_option( 'woolab_icdic_disable_dic_dicdph_match', 'no' ) !== 'yes' ),
+		'check_dic_dph_match'   => (bool) woolab_icdic_dic_dicdph_match_enabled(),
 		'country_in_eu'         => $countries->isCountryCodeInEU( $country ),
 		'verify_vat'            => $verify_vat,
 		// Raw woolab_icdic_ares() result (or falsy) — passed as a callable directly.
@@ -395,7 +393,7 @@ function woolab_icdic_set_vat_exempt_for_customer() {
 	}
 
 	$customer      = WC()->customer;
-	$enabled       = apply_filters( 'woolab_icdic_vat_exempt_enabled', ( get_option('woolab_icdic_vat_exempt_switch', 'no') !== 'no' && wc_tax_enabled() ) );
+	$enabled       = woolab_icdic_vat_exempt_enabled();
 
 	if (empty($customer) || !$enabled) {
 		return;
@@ -427,7 +425,7 @@ function woolab_icdic_set_vat_exempt_for_customer() {
 }
 
 function woolab_icdic_validate_vat_exempt_for_company( $post_data ) {
-	$enabled       = apply_filters( 'woolab_icdic_vat_exempt_enabled', ( get_option('woolab_icdic_vat_exempt_switch', 'no') !== 'no' && wc_tax_enabled() ) );
+	$enabled       = woolab_icdic_vat_exempt_enabled();
 
 	if ( !$enabled ) {
 		return;

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -226,3 +226,41 @@ function woolab_icdic_validate_checkout( array $input ) {
 		'check_fail_ignored' => $vat_check_fail_ignored,
 	);
 }
+
+/**
+ * Pure VAT-exemption decision from a four-state VIES result.
+ *
+ * Mirrors the original exemption body verbatim: a valid VAT number is exempt; a
+ * VIES outage (ViesException, surfaced as 'unverifiable') falls back to the
+ * ignore-check-fail setting; everything else (bad format, format-ok-but-invalid)
+ * is not exempt. Shared by both VAT-exempt hooks.
+ *
+ * @param string $state             'valid'|'bad_format'|'invalid'|'unverifiable' from verify_vat.
+ * @param bool   $ignore_check_fail Whether a VIES outage should still grant exemption.
+ * @return bool
+ */
+function woolab_icdic_vat_exempt_from_state( $state, $ignore_check_fail ) {
+	if ( $state === 'valid' ) {
+		return true;
+	}
+	if ( $state === 'unverifiable' ) {
+		return (bool) $ignore_check_fail;
+	}
+	return false;
+}
+
+/**
+ * Pure selection of which company field carries the VIES-checkable VAT number.
+ *
+ * Slovakia uses the separate DIČ DPH (VAT registration) field; every other
+ * country uses the DIČ field. This rule is shared by the checkout validation
+ * and both VAT-exempt hooks.
+ *
+ * @param string $country Billing country code.
+ * @param string $dic     DIČ value.
+ * @param string $dic_dph DIČ DPH value.
+ * @return string
+ */
+function woolab_icdic_select_vat_number( $country, $dic, $dic_dph ) {
+	return $country === 'SK' ? $dic_dph : $dic;
+}

--- a/includes/validation.php
+++ b/includes/validation.php
@@ -1,0 +1,228 @@
+<?php
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Pure validation of the company-identifier checkout fields.
+ *
+ * No WordPress, no WooCommerce, no network, no i18n. The hook adapter in
+ * filters-actions.php resolves all settings/filters/options into the flags,
+ * builds the two network closures, and maps the returned error codes back to
+ * the exact original wc_add_notice() strings.
+ *
+ * @param array $input {
+ *     @type string      country            Billing country code (wc_clean'd).
+ *     @type string      ic                 billing_ic, wc_clean'd (whitespace stripped here).
+ *     @type string      dic                billing_dic, wc_clean'd (whitespace stripped here for VAT use).
+ *     @type bool        dic_present        Whether billing_dic was present in the request (isset).
+ *     @type string      dic_dph            billing_dic_dph, wc_clean'd (whitespace stripped here).
+ *     @type string      company            billing_company, wc_clean'd.
+ *     @type string      postcode           billing_postcode, wc_clean'd.
+ *     @type string      city               billing_city, wc_clean'd.
+ *     @type string      address_1          billing_address_1, wc_clean'd.
+ *     @type bool        ship_to_different  Whether ship-to-different-address is checked.
+ *     @type string|null shipping_country   Shipping country code, or null when not present.
+ *     @type bool        ares_check
+ *     @type bool        ares_fill
+ *     @type bool        vies_check
+ *     @type bool        ignore_check_fail
+ *     @type bool        check_country_match
+ *     @type bool        require_sk_ic_and_dic
+ *     @type bool        check_dic_dph_match
+ *     @type bool        country_in_eu      Resolved from ibericode Countries::isCountryCodeInEU().
+ *     @type callable    verify_vat         fn(string $vat): string 'valid'|'bad_format'|'invalid'|'unverifiable'
+ *     @type callable    lookup_ares        fn(string $ico): array   raw woolab_icdic_ares() result (or falsy)
+ * }
+ *
+ * @return array {
+ *     @type array $errors             List of ['code' => string, 'data' => array]; 'data' omitted when unused.
+ *     @type bool  $check_fail_ignored Whether a VAT/ARES check failure was ignored.
+ * }
+ */
+function woolab_icdic_validate_checkout( array $input ) {
+
+	$country = $input['country'];
+
+	$errors                 = array();
+	$vat_check_fail_ignored = false;
+
+	// Remove white spaces (matches the original preg_replace cleaning).
+	$ico     = preg_replace( '/\s+/', '', $input['ic'] );
+	$dic     = preg_replace( '/\s+/', '', $input['dic'] );
+	$dic_dph = preg_replace( '/\s+/', '', $input['dic_dph'] );
+
+	// BUSINESS ID
+	if ( $input['ic'] ) {
+
+		// CZ
+		if ( $country == 'CZ' ) {
+
+			// ARES Check Enabled
+			if ( $input['ares_check'] ) {
+
+				$ares = $input['lookup_ares']( $ico );
+				if ( $ares ) {
+					if ( $ares['error'] ) {
+						$is_internal_error = ( ! empty( $ares['internal_error'] ) );
+
+						if ( $is_internal_error && $input['ignore_check_fail'] ) {
+							$vat_check_fail_ignored = true;
+						} else {
+							$errors[] = array( 'code' => 'invalid_business_id', 'data' => array( 'ares_message' => $ares['error'] ) );
+						}
+					} elseif ( $input['ares_fill'] ) {
+						$missing_fields = array();
+						if ( $input['dic_present'] && $input['dic'] != $ares['dic'] ) {
+							$missing_fields[] = 'tax_id';
+						}
+						if ( $input['company'] != $ares['spolecnost'] ) {
+							$missing_fields[] = 'company';
+						}
+						if ( $input['postcode'] != $ares['psc'] ) {
+							$missing_fields[] = 'postcode';
+						}
+						if ( $input['city'] != $ares['mesto'] ) {
+							$missing_fields[] = 'city';
+						}
+						if ( $input['address_1'] != $ares['adresa'] ) {
+							$missing_fields[] = 'address';
+						}
+						if ( $missing_fields ) {
+							$errors[] = array( 'code' => 'ares_mismatch', 'data' => array( 'fields' => $missing_fields ) );
+						}
+					}
+				} else {
+					if ( $input['ignore_check_fail'] ) {
+						$vat_check_fail_ignored = true;
+					} else {
+						$errors[] = array( 'code' => 'ares_unexpected' );
+					}
+				}
+
+			// ARES Check Disabled
+			} elseif ( ! woolab_icdic_verify_ic( $ico ) ) {
+				$errors[] = array( 'code' => 'invalid_business_id' );
+			}
+
+		// SK
+		} elseif ( $country == 'SK' ) {
+			if ( $ico ) {
+				if ( ! woolab_icdic_verify_ic( $ico ) ) {
+					$errors[] = array( 'code' => 'invalid_business_id' );
+				}
+			}
+		}
+
+	}
+
+	// VAT / DIC
+	if ( $input['dic'] ) {
+
+		// Check if in EU
+		if ( $input['country_in_eu'] ) {
+
+			// If Validate in VIES
+			// Slovak DIC cannot (and shouldn't) be validated in VIES
+			if ( $input['vies_check'] && $country != 'SK' ) {
+
+				// Match VAT country prefix and country code.
+				if ( $input['check_country_match'] && woolab_icdic_get_vat_number_country_code( $dic ) !== $country ) {
+					$errors[] = array( 'code' => 'vat_country_mismatch_billing' );
+				}
+
+				// Match VAT country prefix and shipping country code.
+				if ( $input['check_country_match'] && $input['ship_to_different'] && $input['shipping_country'] !== null && woolab_icdic_get_vat_number_country_code( $dic ) !== $input['shipping_country'] ) {
+					$errors[] = array( 'code' => 'vat_country_mismatch_shipping' );
+				}
+
+				$state = $input['verify_vat']( $dic );
+
+				if ( $state === 'bad_format' ) {
+					// Original emits BOTH notices: validateVatNumberFormat() false, then
+					// validateVatNumber() short-circuits to false (no VIES call, no exception).
+					$errors[] = array( 'code' => 'vat_format' );
+					$errors[] = array( 'code' => 'invalid_vat' );
+				} elseif ( $state === 'invalid' ) {
+					$errors[] = array( 'code' => 'invalid_vat' );
+				} elseif ( $state === 'unverifiable' ) {
+					if ( $input['ignore_check_fail'] ) {
+						$vat_check_fail_ignored = true;
+					} else {
+						$errors[] = array( 'code' => 'vat_unverifiable' );
+					}
+				}
+
+			// Validate CZ and SK mathematicaly
+			} else {
+				if ( $country == 'CZ' ) {
+					if ( ! ( woolab_icdic_verify_rc( substr( $dic, 2 ) ) || woolab_icdic_verify_dic( substr( $dic, 2 ) ) ) || substr( $dic, 0, 2 ) != 'CZ' ) {
+						$errors[] = array( 'code' => 'invalid_dic_cz' );
+					}
+				} elseif ( $country == 'SK' ) {
+					if ( ! woolab_icdic_verify_dic_sk( $dic ) ) {
+						$errors[] = array( 'code' => 'invalid_tax_id_sk' );
+					}
+				}
+			}
+
+		}
+
+	}
+	// DIC is mandatory in Slovakia, this is not a VAT number
+	else {
+		// if IC is set, DIC must be set as well in Slovakia
+		if ( $input['require_sk_ic_and_dic'] && ! empty( $input['ic'] ) && empty( $input['dic'] ) && $country == 'SK' ) {
+			$errors[] = array( 'code' => 'invalid_tax_id_sk' );
+		}
+	}
+
+	// IC DPH / DIC DPH
+	if ( $input['dic_dph'] && $country == 'SK' ) {
+
+		// Match VAT country prefix and country code.
+		if ( $input['check_country_match'] && woolab_icdic_get_vat_number_country_code( $dic_dph ) !== $country ) {
+			$errors[] = array( 'code' => 'vat_country_mismatch_billing' );
+		}
+
+		// Verify IC DPH
+		// If Validate in VIES
+		if ( $input['vies_check'] ) {
+
+			$state = $input['verify_vat']( $dic_dph );
+
+			if ( $state === 'unverifiable' ) {
+				if ( $input['ignore_check_fail'] ) {
+					$vat_check_fail_ignored = true;
+				} else {
+					$errors[] = array( 'code' => 'vat_unverifiable' );
+				}
+			} elseif ( $state !== 'valid' ) {
+				// Original only calls validateVatNumber() here (no separate format
+				// notice), so both 'bad_format' and 'invalid' yield a single notice.
+				$errors[] = array( 'code' => 'invalid_vat_dph' );
+			}
+
+		} else {
+
+			if ( ! woolab_icdic_verify_dic_dph_sk( $dic_dph ) ) {
+				$errors[] = array( 'code' => 'invalid_vat_dph' );
+			}
+
+		}
+
+		// IC DPH has to match to Tax ID number without SK
+		if ( $input['check_dic_dph_match'] && $dic_dph && $dic ) {
+			if ( $dic != substr( $dic_dph, 2 ) ) {
+				$errors[] = array( 'code' => 'dic_dph_mismatch' );
+			}
+		}
+	}
+
+	return array(
+		'errors'             => $errors,
+		'check_fail_ignored' => $vat_check_fail_ignored,
+	);
+}

--- a/readme.txt
+++ b/readme.txt
@@ -131,10 +131,6 @@ Either post it on [GitHub](https://github.com/vyskoczilova/kybernaut-ic-dic) or�
 = 1.11.0 (2026-06-26) =
 
 * Refactor: Internal architecture cleanup with no change to checkout behaviour, validation messages, or public filters. The checkout field validation was extracted into a pure, unit-tested orchestrator behind a thin hook adapter; the two duplicated VAT-exemption code paths were collapsed onto a single shared VIES verification routine; and all settings reads were consolidated behind named accessors.
-* Dev: Added substantial unit-test coverage for the checkout validation and VAT-exemption logic.
-
-= 1.10.6 (2026-06-26) =
-
 * Fix: The SK-only "VAT reg. no." (IČ DPH) field now shows only for Slovak orders on the admin order edit screen. Two issues were fixed: an off-by-one country comparison (`$country[0]` only checked the first character) in the field definition, and the country-based show/hide script not loading on HPOS order edit screens, which left the field visible on Czech orders.
 * Fix: Fatal error on every page load for logged-in EU B2B customers when VIES was unavailable — `ViesException` was re-thrown from the `init` hook and the `update_order_review` AJAX call; the exception is now caught, logged, and treated as "not exempt" instead.
 * Fix: ARES mismatch notice for Tax ID field incorrectly reported the field as "Business ID".

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ Either post it on [GitHub](https://github.com/vyskoczilova/kybernaut-ic-dic) orâ
 * Security: `ajaxAres` endpoint now verifies a nonce and sanitizes the `ico` request parameter.
 * Security: Notice-dismiss AJAX endpoint is restricted to authenticated users with the `manage_woocommerce` capability and now requires a nonce.
 * Security: Raw `$_POST` reads in checkout validation wrapped in `wc_clean( wp_unslash() )`, consistent with the rest of the codebase.
+* Dev: The distributed plugin no longer bundles development-only files â€” the `docs/` directory, `phpunit.xml`, and editor config are excluded from the build (tests were already excluded).
 
 = 1.10.5 (2026-03-25) =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: vyskoczilova
 Tags: DIČ, IČO, IČ, IČ DPH, VAT number
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 1.10.6
+Stable tag: 1.11.0
 Requires PHP: 7.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -127,6 +127,11 @@ Either post it on [GitHub](https://github.com/vyskoczilova/kybernaut-ic-dic) or�
 
 
 == Changelog ==
+
+= 1.11.0 (2026-06-26) =
+
+* Refactor: Internal architecture cleanup with no change to checkout behaviour, validation messages, or public filters. The checkout field validation was extracted into a pure, unit-tested orchestrator behind a thin hook adapter; the two duplicated VAT-exemption code paths were collapsed onto a single shared VIES verification routine; and all settings reads were consolidated behind named accessors.
+* Dev: Added substantial unit-test coverage for the checkout validation and VAT-exemption logic.
 
 = 1.10.6 (2026-06-26) =
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,4 +15,5 @@ WP_Mock::bootstrap();
 
 require_once dirname(__DIR__) . '/includes/ares.php';
 require_once dirname(__DIR__) . '/includes/helpers.php';
+require_once dirname(__DIR__) . '/includes/validation.php';
 require_once dirname(__DIR__) . '/includes/logger.php';

--- a/tests/unit/ValidationTest.php
+++ b/tests/unit/ValidationTest.php
@@ -1,0 +1,437 @@
+<?php
+
+namespace KybernautIcDic\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization tests for the pure checkout validation orchestrator in
+ * includes/validation.php.
+ *
+ * woolab_icdic_validate_checkout() is pure (no WordPress, no network, no i18n),
+ * so no WP_Mock setup is needed. Network is supplied via fake closures and
+ * assertions are made on returned error *codes*, never translated strings.
+ */
+class ValidationTest extends TestCase {
+
+	/**
+	 * Build an $input array with neutral defaults; override per test.
+	 */
+	private function input( array $over = array() ) {
+		return array_merge( array(
+			'country'               => 'CZ',
+			'ic'                    => '',
+			'dic'                   => '',
+			'dic_present'           => true,
+			'dic_dph'               => '',
+			'company'               => '',
+			'postcode'              => '',
+			'city'                  => '',
+			'address_1'             => '',
+			'ship_to_different'     => false,
+			'shipping_country'      => null,
+			'ares_check'            => true,
+			'ares_fill'             => false,
+			'vies_check'            => true,
+			'ignore_check_fail'     => false,
+			'check_country_match'   => true,
+			'require_sk_ic_and_dic' => true,
+			'check_dic_dph_match'   => true,
+			'country_in_eu'         => true,
+			'verify_vat'            => function ( $v ) { return 'valid'; },
+			'lookup_ares'           => function ( $ico ) { return false; },
+		), $over );
+	}
+
+	/** Extract just the error codes, in order. */
+	private function codes( array $result ) {
+		return array_map( function ( $e ) { return $e['code']; }, $result['errors'] );
+	}
+
+	// --- empty / no-op -----------------------------------------------------
+
+	public function testNoFieldsNoErrors() {
+		$result = woolab_icdic_validate_checkout( $this->input() );
+		$this->assertSame( array(), $this->codes( $result ) );
+		$this->assertFalse( $result['check_fail_ignored'] );
+	}
+
+	// --- CZ Business ID, ARES disabled (math) ------------------------------
+
+	public function testCzIcAresDisabledValid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'         => '27082440',
+			'ares_check' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testCzIcAresDisabledInvalid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'         => '27082441',
+			'ares_check' => false,
+		) ) );
+		$this->assertSame( array( 'invalid_business_id' ), $this->codes( $result ) );
+	}
+
+	// --- CZ Business ID, ARES enabled --------------------------------------
+
+	public function testCzIcAresErrorMessage() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'lookup_ares' => function ( $ico ) {
+				return array( 'error' => 'Subject not found.' );
+			},
+		) ) );
+		$this->assertSame( array( 'invalid_business_id' ), $this->codes( $result ) );
+		$this->assertSame( 'Subject not found.', $result['errors'][0]['data']['ares_message'] );
+		$this->assertFalse( $result['check_fail_ignored'] );
+	}
+
+	public function testCzIcAresInternalErrorIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'                => '27082440',
+			'ignore_check_fail' => true,
+			'lookup_ares'       => function ( $ico ) {
+				return array( 'error' => 'ARES is not responding.', 'internal_error' => true );
+			},
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+		$this->assertTrue( $result['check_fail_ignored'] );
+	}
+
+	public function testCzIcAresInternalErrorNotIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'lookup_ares' => function ( $ico ) {
+				return array( 'error' => 'ARES is not responding.', 'internal_error' => true );
+			},
+		) ) );
+		$this->assertSame( array( 'invalid_business_id' ), $this->codes( $result ) );
+		$this->assertFalse( $result['check_fail_ignored'] );
+	}
+
+	public function testCzIcAresFalsyUnexpected() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'lookup_ares' => function ( $ico ) { return false; },
+		) ) );
+		$this->assertSame( array( 'ares_unexpected' ), $this->codes( $result ) );
+	}
+
+	public function testCzIcAresFalsyIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'                => '27082440',
+			'ignore_check_fail' => true,
+			'lookup_ares'       => function ( $ico ) { return false; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+		$this->assertTrue( $result['check_fail_ignored'] );
+	}
+
+	public function testCzIcAresFillMismatch() {
+		$ares = array(
+			'error'      => false,
+			'dic'        => 'CZ27082440',
+			'spolecnost' => 'Alza.cz a.s.',
+			'psc'        => 17000,
+			'mesto'      => 'Praha 7',
+			'adresa'     => 'Jankovcova 1522/53',
+		);
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'ares_fill'   => true,
+			// All form values intentionally differ from ARES.
+			'dic'         => 'CZ99999999',
+			'company'     => 'Wrong s.r.o.',
+			'postcode'    => '10000',
+			'city'        => 'Brno',
+			'address_1'   => 'Somewhere 1',
+			'lookup_ares' => function ( $ico ) use ( $ares ) { return $ares; },
+		) ) );
+		$this->assertSame( array( 'ares_mismatch' ), $this->codes( $result ) );
+		$this->assertSame(
+			array( 'tax_id', 'company', 'postcode', 'city', 'address' ),
+			$result['errors'][0]['data']['fields']
+		);
+	}
+
+	public function testCzIcAresFillAllMatch() {
+		$ares = array(
+			'error'      => false,
+			'dic'        => 'CZ27082440',
+			'spolecnost' => 'Alza.cz a.s.',
+			'psc'        => 17000,
+			'mesto'      => 'Praha 7',
+			'adresa'     => 'Jankovcova 1522/53',
+		);
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'ares_fill'   => true,
+			'dic'         => 'CZ27082440',
+			'company'     => 'Alza.cz a.s.',
+			'postcode'    => 17000,
+			'city'        => 'Praha 7',
+			'address_1'   => 'Jankovcova 1522/53',
+			'lookup_ares' => function ( $ico ) use ( $ares ) { return $ares; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testCzIcAresFillDicAbsentSkipsTaxIdMismatch() {
+		// Quirk preserved from the original: when billing_dic is absent from the
+		// request, the Tax ID mismatch check is skipped entirely (isset guard).
+		$ares = array(
+			'error'      => false,
+			'dic'        => 'CZ27082440',
+			'spolecnost' => 'Alza.cz a.s.',
+			'psc'        => 17000,
+			'mesto'      => 'Praha 7',
+			'adresa'     => 'Jankovcova 1522/53',
+		);
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'ic'          => '27082440',
+			'ares_fill'   => true,
+			'dic'         => '',
+			'dic_present' => false,
+			'company'     => 'Alza.cz a.s.',
+			'postcode'    => 17000,
+			'city'        => 'Praha 7',
+			'address_1'   => 'Jankovcova 1522/53',
+			'lookup_ares' => function ( $ico ) use ( $ares ) { return $ares; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	// --- SK Business ID ----------------------------------------------------
+
+	public function testSkIcInvalid() {
+		// Provide a valid DIC so the SK-required-DIC rule does not also fire,
+		// isolating the IC validation.
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'SK',
+			'ic'      => '27082441',
+			'dic'     => '2020317057',
+		) ) );
+		$this->assertSame( array( 'invalid_business_id' ), $this->codes( $result ) );
+	}
+
+	// --- CZ / SK DIC, mathematical path (VIES off or SK) -------------------
+
+	public function testCzDicMathValid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'dic'        => 'CZ27082440',
+			'vies_check' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testCzDicMathInvalid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'dic'        => 'CZ12345678',
+			'vies_check' => false,
+		) ) );
+		$this->assertSame( array( 'invalid_dic_cz' ), $this->codes( $result ) );
+	}
+
+	public function testSkDicMathValid() {
+		// SK never goes through VIES, even with vies_check on.
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'SK',
+			'dic'     => '2020317057',
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testSkDicMathInvalid() {
+		// 9 digits — fails the SK DIC 10-digit numeric check.
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'SK',
+			'dic'     => '123456789',
+		) ) );
+		$this->assertSame( array( 'invalid_tax_id_sk' ), $this->codes( $result ) );
+	}
+
+	public function testDicNotInEuSkipsBlock() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'       => 'US',
+			'dic'           => 'GARBAGE',
+			'country_in_eu' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	// --- EU DIC, VIES path -------------------------------------------------
+
+	public function testEuDicViesValid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'DE',
+			'dic'        => 'DE123456789',
+			'verify_vat' => function ( $v ) { return 'valid'; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testEuDicViesInvalid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'DE',
+			'dic'        => 'DE123456789',
+			'verify_vat' => function ( $v ) { return 'invalid'; },
+		) ) );
+		$this->assertSame( array( 'invalid_vat' ), $this->codes( $result ) );
+	}
+
+	public function testEuDicViesBadFormatEmitsBothNotices() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'DE',
+			'dic'        => 'DExx',
+			'verify_vat' => function ( $v ) { return 'bad_format'; },
+		) ) );
+		$this->assertSame( array( 'vat_format', 'invalid_vat' ), $this->codes( $result ) );
+	}
+
+	public function testEuDicViesUnverifiableNotIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'DE',
+			'dic'        => 'DE123456789',
+			'verify_vat' => function ( $v ) { return 'unverifiable'; },
+		) ) );
+		$this->assertSame( array( 'vat_unverifiable' ), $this->codes( $result ) );
+		$this->assertFalse( $result['check_fail_ignored'] );
+	}
+
+	public function testEuDicViesUnverifiableIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'           => 'DE',
+			'dic'               => 'DE123456789',
+			'ignore_check_fail' => true,
+			'verify_vat'        => function ( $v ) { return 'unverifiable'; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+		$this->assertTrue( $result['check_fail_ignored'] );
+	}
+
+	public function testEuDicViesBillingCountryMismatch() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'DE',
+			'dic'     => 'FR123456789',
+		) ) );
+		$this->assertSame( array( 'vat_country_mismatch_billing' ), $this->codes( $result ) );
+	}
+
+	public function testEuDicViesShippingCountryMismatch() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'          => 'DE',
+			'dic'              => 'DE123456789',
+			'ship_to_different'=> true,
+			'shipping_country' => 'FR',
+		) ) );
+		$this->assertSame( array( 'vat_country_mismatch_shipping' ), $this->codes( $result ) );
+	}
+
+	public function testEuDicViesCountryMatchDisabled() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'             => 'DE',
+			'dic'                 => 'FR123456789',
+			'check_country_match' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	// --- SK required IC + DIC ----------------------------------------------
+
+	public function testSkRequiredDicMissing() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'SK',
+			'ic'      => '27082440',
+			'dic'     => '',
+		) ) );
+		$this->assertSame( array( 'invalid_tax_id_sk' ), $this->codes( $result ) );
+	}
+
+	public function testSkRequiredDisabledNoError() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'               => 'SK',
+			'ic'                    => '27082440',
+			'dic'                   => '',
+			'require_sk_ic_and_dic' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	// --- SK IC DPH ---------------------------------------------------------
+
+	public function testIcDphViesValidAndMatches() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'SK',
+			'dic'        => '2020317057',
+			'dic_dph'    => 'SK2020317057',
+			'verify_vat' => function ( $v ) { return 'valid'; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testIcDphViesInvalid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'SK',
+			'dic'        => '2020317057',
+			'dic_dph'    => 'SK2020317057',
+			'verify_vat' => function ( $v ) { return 'invalid'; },
+		) ) );
+		$this->assertSame( array( 'invalid_vat_dph' ), $this->codes( $result ) );
+	}
+
+	public function testIcDphMathInvalid() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'SK',
+			'dic_dph'    => 'SK2020317058',
+			'vies_check' => false,
+		) ) );
+		$this->assertSame( array( 'invalid_vat_dph' ), $this->codes( $result ) );
+	}
+
+	public function testIcDphCountryMismatch() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'    => 'SK',
+			'dic_dph'    => 'CZ2020317057',
+			'vies_check' => false,
+		) ) );
+		// Country-prefix mismatch first, then the non-VIES math check fails too,
+		// then the DIC/DIC-DPH match check is skipped (no $dic). Order preserved.
+		$this->assertSame(
+			array( 'vat_country_mismatch_billing', 'invalid_vat_dph' ),
+			$this->codes( $result )
+		);
+	}
+
+	public function testIcDphDoesNotMatchDic() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country' => 'SK',
+			'dic'     => '2020317057',
+			'dic_dph' => 'SK9999999999',
+		) ) );
+		$this->assertSame( array( 'dic_dph_mismatch' ), $this->codes( $result ) );
+	}
+
+	public function testIcDphMatchCheckDisabled() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'             => 'SK',
+			'dic'                 => '2020317057',
+			'dic_dph'             => 'SK9999999999',
+			'check_dic_dph_match' => false,
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+	}
+
+	public function testIcDphViesUnverifiableIgnored() {
+		$result = woolab_icdic_validate_checkout( $this->input( array(
+			'country'           => 'SK',
+			'dic'               => '2020317057',
+			'dic_dph'           => 'SK2020317057',
+			'ignore_check_fail' => true,
+			'verify_vat'        => function ( $v ) { return 'unverifiable'; },
+		) ) );
+		$this->assertSame( array(), $this->codes( $result ) );
+		$this->assertTrue( $result['check_fail_ignored'] );
+	}
+}

--- a/tests/unit/ValidationTest.php
+++ b/tests/unit/ValidationTest.php
@@ -434,4 +434,43 @@ class ValidationTest extends TestCase {
 		$this->assertSame( array(), $this->codes( $result ) );
 		$this->assertTrue( $result['check_fail_ignored'] );
 	}
+
+	// --- VAT-exemption helpers (candidate 3) -------------------------------
+
+	/**
+	 * @dataProvider providerVatExemptFromState
+	 */
+	public function testVatExemptFromState( $state, $ignore, $expected ) {
+		$this->assertSame( $expected, woolab_icdic_vat_exempt_from_state( $state, $ignore ) );
+	}
+
+	public static function providerVatExemptFromState() {
+		return array(
+			'valid is exempt (ignore off)'        => array( 'valid', false, true ),
+			'valid is exempt (ignore on)'         => array( 'valid', true, true ),
+			'invalid not exempt'                  => array( 'invalid', false, false ),
+			'invalid not exempt (ignore on)'      => array( 'invalid', true, false ),
+			'bad format not exempt'               => array( 'bad_format', false, false ),
+			'bad format not exempt (ignore on)'   => array( 'bad_format', true, false ),
+			'unverifiable follows ignore: off'    => array( 'unverifiable', false, false ),
+			'unverifiable follows ignore: on'     => array( 'unverifiable', true, true ),
+		);
+	}
+
+	/**
+	 * @dataProvider providerSelectVatNumber
+	 */
+	public function testSelectVatNumber( $country, $dic, $dic_dph, $expected ) {
+		$this->assertSame( $expected, woolab_icdic_select_vat_number( $country, $dic, $dic_dph ) );
+	}
+
+	public static function providerSelectVatNumber() {
+		return array(
+			'SK uses dic_dph'        => array( 'SK', '2020317057', 'SK2020317057', 'SK2020317057' ),
+			'CZ uses dic'            => array( 'CZ', 'CZ27082440', '', 'CZ27082440' ),
+			'other EU uses dic'      => array( 'DE', 'DE123456789', '', 'DE123456789' ),
+			'SK empty dic_dph'       => array( 'SK', '2020317057', '', '' ),
+			'CZ empty dic'           => array( 'CZ', '', '', '' ),
+		);
+	}
 }

--- a/woolab-ic-dic.php
+++ b/woolab-ic-dic.php
@@ -3,7 +3,7 @@
  Plugin Name:			Kybernaut IC DIC
  Plugin URI:			https://kybernaut.cz/pluginy/kybernaut-ic-dic
  Description:			Adds Czech Company & VAT numbers (IČO & DIČ) to WooCommerce billing fields and verifies if data are correct.
- Version:				1.10.6
+ Version:				1.11.0
  Author:				Karolína Vyskočilová
  Author URI:			https://kybernaut.cz
  Text Domain:			woolab-ic-dic
@@ -40,7 +40,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 define( 'WOOLAB_IC_DIC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'WOOLAB_IC_DIC_ABSPATH', dirname( __FILE__ ) . '/' );
 define( 'WOOLAB_IC_DIC_URL', plugin_dir_url( __FILE__ ) );
-define( 'WOOLAB_IC_DIC_VERSION', '1.10.6' );
+define( 'WOOLAB_IC_DIC_VERSION', '1.11.0' );
 
 // Check if WooCommerce active
 function woolab_icdic_init() {

--- a/woolab-ic-dic.php
+++ b/woolab-ic-dic.php
@@ -84,6 +84,7 @@ function woolab_icdic_init() {
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/admin-notice.php');
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/ares.php');
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/helpers.php');
+		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/validation.php');
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/filters-actions.php');
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/settings.php');
 		include_once( WOOLAB_IC_DIC_ABSPATH . 'includes/logger.php');

--- a/woolab-ic-dic.php
+++ b/woolab-ic-dic.php
@@ -149,7 +149,7 @@ function woolab_icdic_enqueue_scripts() {
 			'ares_fill' => woolab_icdic_ares_fill(),
 			'ignore_check_fail' => woolab_icdic_ignore_check_fail(),
 		));
-		if ( apply_filters( 'woolab_icdic_toggle', get_option('woolab_icdic_toggle_switch', 'no') ) === 'yes') {
+		if ( woolab_icdic_toggle_enabled() ) {
 			wp_enqueue_style( 'woolab-icdic-public-css', WOOLAB_IC_DIC_URL . 'assets/css/style.css', null, WOOLAB_IC_DIC_VERSION );
 		}
 	}
@@ -179,6 +179,40 @@ function woolab_icdic_vies_check() {
 function woolab_icdic_ignore_check_fail() {
 	$option = woolab_icdic_get_option( 'woolab_icdic_ignore_check_fail', 'no' );
 	return apply_filters( 'woolab_icdic_ignore_check_fail', $option );
+}
+
+/**
+ * Whether automatic VAT exemption for valid intra-EU B2B is enabled.
+ * Filter receives (and returns) a bool, matching the original call sites.
+ */
+function woolab_icdic_vat_exempt_enabled() {
+	return apply_filters( 'woolab_icdic_vat_exempt_enabled', ( get_option( 'woolab_icdic_vat_exempt_switch', 'no' ) !== 'no' && wc_tax_enabled() ) );
+}
+
+/**
+ * Whether the SK DIČ ↔ IČ DPH match check is enabled. Stored as an inverted
+ * "disable" option. Filter receives (and returns) a bool.
+ */
+function woolab_icdic_dic_dicdph_match_enabled() {
+	return apply_filters( 'woolab_icdic_enable_dic_dicdph_match_check', get_option( 'woolab_icdic_disable_dic_dicdph_match', 'no' ) !== 'yes' );
+}
+
+/**
+ * Whether the "buying as a company" fields toggle is enabled.
+ * Filter receives (and returns) the raw 'yes'/'no' string; normalization to bool
+ * happens here.
+ */
+function woolab_icdic_toggle_enabled() {
+	return apply_filters( 'woolab_icdic_toggle', get_option( 'woolab_icdic_toggle_switch', 'no' ) ) !== 'no';
+}
+
+/**
+ * Whether the country field is moved above the toggle.
+ * Filter receives (and returns) the raw 'yes'/'no' string; normalization to bool
+ * happens here.
+ */
+function woolab_icdic_country_ontop_enabled() {
+	return apply_filters( 'woolab_icdic_country_ontop', get_option( 'woolab_icdic_country_switch', 'no' ) ) !== 'no';
 }
 
 function woolab_icdic_get_option( $name, $default = 'yes' ) {

--- a/woolab-ic-dic.php
+++ b/woolab-ic-dic.php
@@ -181,6 +181,15 @@ function woolab_icdic_ignore_check_fail() {
 	return apply_filters( 'woolab_icdic_ignore_check_fail', $option );
 }
 
+// NOTE: the four accessors below deliberately do NOT go through
+// woolab_icdic_get_option(). Each preserves its original public filter contract,
+// which differs from the helpers above: the vat_exempt/dic_dicdph filters receive
+// an already-computed bool (and vat_exempt ANDs in wc_tax_enabled / dic_dicdph is
+// an inverted "disable" option), while the toggle/country filters receive the raw
+// 'yes'/'no' string and are normalized with `!== 'no'` afterwards. Routing any of
+// these through woolab_icdic_get_option() would change what the filter sees or the
+// truthiness — do not "consolidate" them into it.
+
 /**
  * Whether automatic VAT exemption for valid intra-EU B2B is enabled.
  * Filter receives (and returns) a bool, matching the original call sites.


### PR DESCRIPTION
## Summary

Behavior-preserving architecture refactor of the plugin's core, extracted from the architecture review. Five refactor commits + a minor version bump. No change to checkout behavior, validation messages, or public filters — confirmed by unit tests **and** live checkout (CZ + SK).

### What changed
- **Candidate 1 — checkout validation orchestrator** (`47818e8`): extracted `woolab_icdic_checkout_field_process()`'s ~220-line monolith into a pure, WordPress-free `woolab_icdic_validate_checkout()` (returns structured error codes) behind a thin hook adapter. Only ARES/VIES network crosses the seam, as closures. New `includes/validation.php`.
- **Candidate 3 — VAT-exempt twins** (`55dd010`): collapsed the two near-identical VAT-exemption code paths onto one shared VIES verification seam + pure helpers (`woolab_icdic_vat_exempt_from_state`, `woolab_icdic_select_vat_number`). The hooks' distinct gating (EU check, `is_company`, data source) is preserved, not erased.
- **Candidate 2 — settings read seam** (`a282bbc`): consolidated the four raw `get_option(...) yes/no` reads behind named accessors; public filter contracts preserved.
- **Cleanup** (`119e6c0`): `/simplify` pass — deduped the verifier-build block, inlined single-use locals, documented why the settings accessors bypass `woolab_icdic_get_option()`.
- **Release** (`b4bf7f1`, `eab0fa3`): bump `1.10.6` -> **`1.11.0`** (minor, reflecting the architectural scope) + changelog notes.

### Testing
- `composer test:unit` -> **106 tests / 118 assertions, green** (added `tests/unit/ValidationTest.php`; existing Helpers/Ares unchanged).
- **Live checkout** verified on a local WooCommerce (base CZ, taxes on):
  - CZ bad IC -> ARES error notice; malformed EU VAT -> both `vat_format` + `invalid_vat` (the dual-notice behavior preserved).
  - SK DIC<->IC-DPH mismatch -> "Tax ID or VAT number is not valid."
  - SK B2B valid VIES number -> VAT exemption applied (subtotal net, no VAT line).
  - Company toggle ON -> checkbox + fields + CSS render correctly.

### Notes
- No new security sinks; all `$_POST` reads sanitized via `wc_clean( wp_unslash() )`. Pre-push review verdict: SAFE TO PUSH.
- One **pre-existing** (not introduced here) item for a future ticket: `set_vat_exempt_for_customer` can reach a synchronous VIES call on `init`; the refactor preserved this exactly.
- Design docs included under `docs/plans/` and `docs/adr/` for reviewer context.
