### PR TITLE
perf: cache ARES and VIES lookups to avoid repeated external calls

### DIFF
--- a/includes/ares.php
+++ b/includes/ares.php
@@ -25,6 +25,15 @@ if ( ! function_exists( 'woolab_icdic_ares') ) {
             return array( 'error' => __('Business ID must be a number and 8 digits long.', 'woolab-ic-dic'));
         }
 
+        // Serve a cached lookup when available. ARES data changes rarely, and the
+        // AJAX autofill endpoint is unauthenticated, so caching both spares the
+        // remote registry and prevents the store from being rate-limited by ARES.
+        $cache_key = 'woolab_icdic_ares_' . $ico;
+        $cached    = get_transient( $cache_key );
+        if ( is_array( $cached ) ) {
+            return $cached;
+        }
+
         $url = 'https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/ekonomicke-subjekty/' . $ico;
         $response = wp_remote_get( $url );
         $logger = Logger::getInstance();
@@ -79,6 +88,16 @@ if ( ! function_exists( 'woolab_icdic_ares') ) {
 				'error'          => __('An error occured while connecting to ARES, try it again later.', 'woolab-ic-dic'),
 				'internal_error' => true,
             );
+        }
+
+        // Cache only definitive answers (a parsed subject or a confirmed 404).
+        // Transient failures (network error, ARES down) carry 'internal_error'
+        // and must not be cached so the next request can retry.
+        if ( empty( $return['internal_error'] ) ) {
+            $ttl = apply_filters( 'woolab_icdic_ares_cache_ttl', DAY_IN_SECONDS, $ico, $return );
+            if ( $ttl > 0 ) {
+                set_transient( $cache_key, $return, $ttl );
+            }
         }
 
         return $return;

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -169,8 +169,24 @@ function woolab_icdic_make_vies_verifier( $log_message ) {
 			return 'bad_format';
 		}
 
+		// A definitive VIES result (valid/invalid) is stable, so cache it. This
+		// matters most for woolab_icdic_set_vat_exempt_for_customer(), which runs
+		// on init on every front-end page load and would otherwise issue a fresh
+		// synchronous SOAP request each time. Outages ('unverifiable') are never
+		// cached so the next request can retry.
+		$cache_key = 'woolab_icdic_vies_' . md5( $vat );
+		$cached    = get_transient( $cache_key );
+		if ( 'valid' === $cached || 'invalid' === $cached ) {
+			return $cached;
+		}
+
 		try {
-			return $validator->validateVatNumber( $vat ) ? 'valid' : 'invalid';
+			$state = $validator->validateVatNumber( $vat ) ? 'valid' : 'invalid';
+			$ttl   = apply_filters( 'woolab_icdic_vies_cache_ttl', DAY_IN_SECONDS, $vat, $state );
+			if ( $ttl > 0 ) {
+				set_transient( $cache_key, $state, $ttl );
+			}
+			return $state;
 		} catch ( ViesException $exception ) {
 			$logger = Logger::getInstance();
 			$logger->log( sprintf( $log_message, $vat ) );

--- a/tests/WPMock/wp-functions-mock.php
+++ b/tests/WPMock/wp-functions-mock.php
@@ -123,6 +123,25 @@ if (!function_exists('wp_parse_args')) {
     }
 }
 
+if (!function_exists('get_transient')) {
+    // Always report a cache miss so tests exercise the live lookup path.
+    function get_transient($key)
+    {
+        return false;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($key, $value, $expiration = 0)
+    {
+        return true;
+    }
+}
+
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
 if(!function_exists('wp_json_encode')) {
     function wp_json_encode( $data, $options = 0, $depth = 512 ) {
         return json_encode($data, $options, $depth );


### PR DESCRIPTION
### Description & Link to The Issue

Part of a security & performance review. This is PR 1 of a sequence, addressing the highest-impact finding: uncached synchronous calls to external registries (ARES and VIES) on hot paths.

**Problem**
- `woolab_icdic_ares()` queried the ARES REST API on every call, with no caching.
- The VIES verifier built by `woolab_icdic_make_vies_verifier()` issued a fresh synchronous SOAP request every time. This is worst in `woolab_icdic_set_vat_exempt_for_customer()`, which runs on the `init` hook for **every front-end page load** of a customer whose saved billing country is a foreign EU country — so VIES was being queried on essentially every page view for those customers. VIES is frequently slow or unavailable, adding that latency to each request.

**Fix** — cache both in WordPress transients keyed by the identifier:
- **ARES** (`includes/ares.php`): serve from `woolab_icdic_ares_{ico}` when present; cache only *definitive* answers (a parsed subject or a confirmed 404). Transient failures (network error / ARES down) carry `internal_error` and are deliberately **not** cached so the next request retries. TTL defaults to `DAY_IN_SECONDS`, filterable via `woolab_icdic_ares_cache_ttl`.
- **VIES** (`includes/filters-actions.php`): cache only definitive `valid`/`invalid` results in `woolab_icdic_vies_{md5(vat)}`. Outages (`unverifiable`) are never cached. TTL defaults to `DAY_IN_SECONDS`, filterable via `woolab_icdic_vies_cache_ttl`.

Caching same-identifier lookups also mitigates abuse of the unauthenticated `ajaxAres` endpoint, which otherwise proxies one outbound ARES request per call and could get the store rate-limited by the registry.

The pure validation layer (`includes/validation.php`) is untouched — caching lives entirely inside the network seams it already delegates to.

#### What kind of change does this PR introduce? 

* [x] Bugfix (performance)
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 

* [x] No

Behaviour is unchanged for callers; results are just memoized. Definitive results are cached, failures are not, so no stale error states persist.

### Preview (Screenshot/Gif):

N/A — internal caching. Existing unit suite passes (106 tests); tests use passthrough `get_transient`/`set_transient` mocks that always report a cache miss, so the live-path assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEBvzwRKKLrFdo9ojPNUbh)_