### PR TITLE
security: harden order-meta save handler

### DIFF
--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -614,27 +614,38 @@ function woolab_icdic_process_shop_order ( $post_id, $post ) {
 		return;
 	}
 
+	// The nonce is only rendered on the gated order-edit screen, but verify the
+	// capability explicitly so this handler can never write order/user meta for
+	// a user who cannot edit shop orders.
+	if ( ! current_user_can( 'edit_shop_orders' ) ) {
+		return;
+	}
+
 	$order = wc_get_order( $post_id );
+
+	if ( ! $order instanceof WC_Order ) {
+		return;
+	}
 
 	$update_user_meta = apply_filters( 'woolab_icdic_update_user_meta', false );
 	$user_id          = $order->get_user_id();
 
 	if ( isset($_POST['_billing_billing_ic']) ) {
-		$order->update_meta_data( '_billing_ic', wc_clean( $_POST['_billing_billing_ic'] ) );
+		$order->update_meta_data( '_billing_ic', wc_clean( wp_unslash( $_POST['_billing_billing_ic'] ) ) );
 		if ( $update_user_meta && $user_id !== 0 ) { // Update if not guest.
-			update_user_meta( $user_id, 'billing_ic', sanitize_text_field( $_POST['_billing_billing_ic'] ) );
+			update_user_meta( $user_id, 'billing_ic', sanitize_text_field( wp_unslash( $_POST['_billing_billing_ic'] ) ) );
 		}
 	}
 	if ( isset($_POST['_billing_billing_dic']) ) {
-		$order->update_meta_data( '_billing_dic', wc_clean( $_POST['_billing_billing_dic'] ) );
+		$order->update_meta_data( '_billing_dic', wc_clean( wp_unslash( $_POST['_billing_billing_dic'] ) ) );
 		if ( $update_user_meta && $user_id !== 0 ) { // Update if not guest.
-			update_user_meta( $user_id, 'billing_dic', sanitize_text_field( $_POST['_billing_billing_dic'] ) );
+			update_user_meta( $user_id, 'billing_dic', sanitize_text_field( wp_unslash( $_POST['_billing_billing_dic'] ) ) );
 		}
 	}
 	if ( isset($_POST['_billing_billing_dic_dph']) ) {
-		$order->update_meta_data( '_billing_dic_dph', wc_clean( $_POST['_billing_billing_dic_dph'] ) );
+		$order->update_meta_data( '_billing_dic_dph', wc_clean( wp_unslash( $_POST['_billing_billing_dic_dph'] ) ) );
 		if ( $update_user_meta && $user_id !== 0 ) { // Update if not guest.
-			update_user_meta( $user_id, 'billing_dic_dph', sanitize_text_field( $_POST['_billing_billing_dic_dph'] ) );
+			update_user_meta( $user_id, 'billing_dic_dph', sanitize_text_field( wp_unslash( $_POST['_billing_billing_dic_dph'] ) ) );
 		}
 	}
 


### PR DESCRIPTION
### Description & Link to The Issue

PR 2 of the security & performance review sequence. Hardens `woolab_icdic_process_shop_order()` (`includes/filters-actions.php`), the handler that saves the IČO/DIČ/IČ DPH billing fields when an order is edited in wp-admin.

**Issues addressed**
1. **No capability check.** The handler verified the `woocommerce_save_data` nonce but never checked the user capability. The nonce is only rendered on the gated order-edit screen, so this is defense-in-depth rather than a known exploit — but a capability check is the standard guard here. Added `current_user_can( 'edit_shop_orders' )`.
2. **No guard on `wc_get_order()`.** If it returned `false`, the immediately following `$order->get_user_id()` would fatal. Added an `instanceof WC_Order` bail.
3. **Missing `wp_unslash()`.** `$_POST` values were passed straight into `wc_clean()` / `sanitize_text_field()`, so WordPress' added slashes were persisted. Now unslashed first, matching the checkout path (`woolab_icdic_checkout_field_process`).

#### What kind of change does this PR introduce? 

* [x] Bugfix (security hardening)
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 

* [x] No

Legitimate order edits by shop managers/admins are unaffected; the new guards only reject requests that lack the capability or a valid order.

### Preview (Screenshot/Gif):

N/A — server-side handler. `php -l` clean; unit suite unaffected (this handler is not exercised by the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEBvzwRKKLrFdo9ojPNUbh)_