### PR TITLE
security: escape company identifiers on HTML output

### DIFF
--- a/includes/compatibility/pdf-invoices-and-packing-slips-for-woocommerce.php
+++ b/includes/compatibility/pdf-invoices-and-packing-slips-for-woocommerce.php
@@ -27,13 +27,13 @@ function woolab_icdic_apifw_ps_custom_billing_fields($html, $order_id) {
     }
 
     if ($ic) {
-        $html .= __('Business ID', 'woolab-ic-dic') . ': ' . $ic . '<br/>';
+        $html .= __('Business ID', 'woolab-ic-dic') . ': ' . esc_html( $ic ) . '<br/>';
     }
     if ($dic) {
-        $html .= __('Tax ID', 'woolab-ic-dic') . ': ' . $dic . '<br/>';
+        $html .= __('Tax ID', 'woolab-ic-dic') . ': ' . esc_html( $dic ) . '<br/>';
     }
     if ($ic_dph) {
-        $html .= __('VAT reg. no.', 'woolab-ic-dic') . ': ' . $ic_dph . '<br/>';
+        $html .= __('VAT reg. no.', 'woolab-ic-dic') . ': ' . esc_html( $ic_dph ) . '<br/>';
     }
 
     // Remove the last <br/> to keep the same look.

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -342,12 +342,12 @@ function woolab_icdic_localisation_address_formats($address_formats) {
 // Formatting
 function woolab_icdic_formatted_address_replacements( $replace, $args) {
 	return $replace += array(
-		'{billing_ic}'            => (isset($args['billing_ic']) && $args['billing_ic'] != '' ) ?  __('Business ID: ', 'woolab-ic-dic') .$args['billing_ic'] : '',
-		'{billing_dic}'           => (isset($args['billing_dic']) && $args['billing_dic'] != '') ?  __('Tax ID: ', 'woolab-ic-dic') . $args['billing_dic'] : '',
-		'{billing_dic_dph}'       => (isset($args['billing_dic_dph']) && $args['billing_dic_dph'] != '') ?  __('VAT reg. no.: ', 'woolab-ic-dic') . $args['billing_dic_dph'] : '',
-		'{billing_ic_upper}'      => strtoupper((isset($args['billing_ic_upper']) && $args['billing_ic_upper'] != '') ?__('Business ID: ', 'woolab-ic-dic') . $args['billing_ic_upper'] : '' ),
-		'{billing_dic_upper}'     => strtoupper((isset($args['billing_dic_upper']) && $args['billing_dic_upper'] != '') ? __('Tax ID: ', 'woolab-ic-dic') . $args['billing_dic_upper'] : ''),
-		'{billing_dic_dph_upper}' => strtoupper((isset($args['billing_dic_dph_upper']) && $args['billing_dic_dph_upper'] != '') ? __('VAT reg. no.: ', 'woolab-ic-dic') . $args['billing_dic_dph_upper'] : ''),
+		'{billing_ic}'            => (isset($args['billing_ic']) && $args['billing_ic'] != '' ) ?  __('Business ID: ', 'woolab-ic-dic') . esc_html( $args['billing_ic'] ) : '',
+		'{billing_dic}'           => (isset($args['billing_dic']) && $args['billing_dic'] != '') ?  __('Tax ID: ', 'woolab-ic-dic') . esc_html( $args['billing_dic'] ) : '',
+		'{billing_dic_dph}'       => (isset($args['billing_dic_dph']) && $args['billing_dic_dph'] != '') ?  __('VAT reg. no.: ', 'woolab-ic-dic') . esc_html( $args['billing_dic_dph'] ) : '',
+		'{billing_ic_upper}'      => strtoupper((isset($args['billing_ic_upper']) && $args['billing_ic_upper'] != '') ?__('Business ID: ', 'woolab-ic-dic') . esc_html( $args['billing_ic_upper'] ) : '' ),
+		'{billing_dic_upper}'     => strtoupper((isset($args['billing_dic_upper']) && $args['billing_dic_upper'] != '') ? __('Tax ID: ', 'woolab-ic-dic') . esc_html( $args['billing_dic_upper'] ) : ''),
+		'{billing_dic_dph_upper}' => strtoupper((isset($args['billing_dic_dph_upper']) && $args['billing_dic_dph_upper'] != '') ? __('VAT reg. no.: ', 'woolab-ic-dic') . esc_html( $args['billing_dic_dph_upper'] ) : ''),
 	);
 }
 


### PR DESCRIPTION
### Description & Link to The Issue

PR 3 of the security & performance review sequence. Adds output escaping (defense-in-depth) for the IČO/DIČ/IČ DPH order-meta values where they are concatenated into HTML.

**Locations**
- `includes/compatibility/pdf-invoices-and-packing-slips-for-woocommerce.php` — `woolab_icdic_apifw_ps_custom_billing_fields()` built `... . $ic . '<br/>'` directly.
- `includes/filters-actions.php` — `woolab_icdic_formatted_address_replacements()` inserted `$args['billing_*']` values into the formatted-address replacements unescaped.

These values are sanitized with `wc_clean()` when saved from checkout/admin, so stored XSS is unlikely, but the outputs should still be escaped. Each value is now wrapped in `esc_html()`. The static translated labels ("Business ID: ", etc.) are trusted and left as-is. The values are plain identifiers, so escaping does not change their rendered appearance.

#### What kind of change does this PR introduce? 

* [x] Bugfix (security hardening)
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 

* [x] No

### Preview (Screenshot/Gif):

N/A — `php -l` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEBvzwRKKLrFdo9ojPNUbh)_