### PR TITLE
fix: minor correctness in SK DIČ check, ARES parsing, legacy AJAX

### DIFF
--- a/includes/ares.php
+++ b/includes/ares.php
@@ -50,11 +50,11 @@ if ( ! function_exists( 'woolab_icdic_ares') ) {
                 $cislo_domovni = $data->sidlo->cisloDomovni ?? '';
                 $pismeno_orientacni = $data->sidlo->cisloOrientacniPismeno ?? ''; // TEST
                 $cp = ($cislo_orientacni !== "" ? $cislo_domovni . "/".$cislo_orientacni . $pismeno_orientacni : $cislo_domovni);
-                $ulice  = $data->sidlo->nazevUlice ?? $data->sidlo->nazevObce;
+                $ulice  = $data->sidlo->nazevUlice ?? $data->sidlo->nazevObce ?? '';
 
                 $return['adresa'] = sprintf( '%s %s', $ulice, $cp );
-                $return['psc'] = $data->sidlo->psc;
-                $return['mesto'] = $data->sidlo->nazevMestskehoObvodu ?? $data->sidlo->nazevObce;
+                $return['psc'] = $data->sidlo->psc ?? '';
+                $return['mesto'] = $data->sidlo->nazevMestskehoObvodu ?? $data->sidlo->nazevObce ?? '';
 
                 $logger->logInfo('Ares response:');
                 $logger->logInfo($body);

--- a/includes/filters-actions.php
+++ b/includes/filters-actions.php
@@ -570,7 +570,7 @@ function woolab_icdic_admin_billing_fields ( $fields ) {
 // https://www.jnorton.co.uk/woocommerce-custom-fields
 function woolab_icdic_ajax_get_customer_details_old_woo ( $customer_data ){
 
-	$user_id = $_POST['user_id'];
+	$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
 	$country = get_user_meta( $user_id, 'billing_country', true );
 
 	$customer_data['billing_ic']  = get_user_meta( $user_id, 'billing_ic', true );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -174,7 +174,9 @@ function woolab_icdic_verify_dic_sk( $dic )
 
     // TODO check the sum for Slovak DIC
 
-    return (int) $dic;
+    // Format is valid at this point; return a real bool. Casting to int here
+    // wrongly treated an all-zero DIČ ("0000000000") as invalid (0 == false).
+    return true;
 }
 
 /**


### PR DESCRIPTION
### Description & Link to The Issue

PR 4 (final) of the security & performance review sequence. Three small robustness fixes.

1. **`woolab_icdic_verify_dic_sk()` returned `(int) $dic`** instead of a bool (`includes/helpers.php`). For a format-valid but all-zero DIČ (`"0000000000"`) the cast yields `0`, which reads as invalid. Now returns a real `true` once the 10-digit format check passes. (Existing unit tests already `(bool)`-cast the result, so behaviour for real DIČs is unchanged.)
2. **ARES parsing lacked null-safety** on `$data->sidlo->psc` and the `->nazevObce` fallbacks (`includes/ares.php`). A payload missing those keys emitted PHP warnings; added `?? ''` fallbacks. Present values are unchanged, so the `AresTest` fixtures still pass.
3. **Legacy AJAX handler read `$_POST['user_id']` raw** (`woolab_icdic_ajax_get_customer_details_old_woo`, the WC < 2.7 path). Now `absint( wp_unslash( … ) )`. The capability/nonce are enforced upstream by WooCommerce; this is input hardening.

#### What kind of change does this PR introduce? 

* [x] Bugfix
* [ ] Feature
* [ ] Design
* [ ] Other, please describe:

### Does this PR introduce a breaking change? 

* [x] No

### Preview (Screenshot/Gif):

N/A — `php -l` clean on all three files; full unit suite passes (106 tests, 118 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEBvzwRKKLrFdo9ojPNUbh)_